### PR TITLE
Make the default llama_trainer plugin work on ubuntu

### DIFF
--- a/transformerlab/plugins/llama_trainer/index.json
+++ b/transformerlab/plugins/llama_trainer/index.json
@@ -4,7 +4,7 @@
     "description": "A training script adapted from https://www.philschmid.de/instruction-tune-llama-2 for training Llama2 using PeFT",
     "plugin-format": "python",
     "type": "trainer",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "model_architectures": [
         "LlamaForCausalLM"
     ],

--- a/transformerlab/plugins/llama_trainer/main.py
+++ b/transformerlab/plugins/llama_trainer/main.py
@@ -134,7 +134,8 @@ db.execute(
 )
 db.commit()
 
-max_seq_length = config["maximum_sequence_length"]  # max sequence length for model and packing of the dataset
+max_seq_length = int(config["maximum_sequence_length"])  # max sequence length for model and packing of the dataset
+print(max_seq_length)
 
 args = SFTConfig(
     output_dir=output_dir,
@@ -175,11 +176,9 @@ class ProgressTableUpdateCallback(TrainerCallback):
             # Write to jobs table in database, updating the
             # progress column:
             job.update_progress(progress)
-
-            #changed to let the trainer handle the stopping of the job instead of the table, as the table was prematurely stopping the job
-            #if job.should_stop:
-            #    control.should_training_stop = True
-            #    return control
+            if job.should_stop:
+                control.should_training_stop = True
+                return control
 
         return
 

--- a/transformerlab/plugins/llama_trainer/main.py
+++ b/transformerlab/plugins/llama_trainer/main.py
@@ -7,7 +7,6 @@ import sqlite3
 from string import Template
 from datasets import load_dataset
 from trl import SFTTrainer, SFTConfig
-from transformers import TrainingArguments
 from peft import LoraConfig, prepare_model_for_kbit_training, get_peft_model
 import argparse
 import torch


### PR DESCRIPTION
Made the default llama_trainer plugin actually work on ubuntu by moving the maximum sequence length and packing parameters to the config instead of the trainer. Also switched configs from TrainingArguments to SFTConfig as TrainingArguments doesnt support packing or maximum sequence length. 

Also removed the check for completion in the callback during training as it was prematurely stopping the training. Instead, the training finished when the trainer decides that the training is complete.