### PR TITLE
Feature: Model Zoo - Cancel Download and Delete Model from Cache

### DIFF
--- a/transformerlab/plugins/autotrain_sft_trainer/main.py
+++ b/transformerlab/plugins/autotrain_sft_trainer/main.py
@@ -176,7 +176,7 @@ try:
                 print("Epoch:", epoch)
                 job.update_progress(percent_complete)
 
-                if job.should_stop:
+                if job.should_stop():
                     print("Stopping job because of user interruption.")
                     job.update_status("STOPPED")
                     process.terminate()

--- a/transformerlab/plugins/dpo_orpo_simpo_trainer_llama_factory/main.py
+++ b/transformerlab/plugins/dpo_orpo_simpo_trainer_llama_factory/main.py
@@ -7,6 +7,7 @@ Standard command:
 CUDA_VISIBLE_DEVICES=0 llamafactory-cli train examples/train_lora/llama3_lora_reward.yaml
 
 """
+
 import os
 import subprocess
 import time
@@ -37,8 +38,8 @@ WORKSPACE_DIR = transformerlab.plugin.WORKSPACE_DIR
 
 # Get all parameters provided to this script from Transformer Lab
 parser = argparse.ArgumentParser()
-parser.add_argument('--input_file', type=str)
-parser.add_argument('--experiment_name', default='', type=str)
+parser.add_argument("--input_file", type=str)
+parser.add_argument("--experiment_name", default="", type=str)
 args, unknown = parser.parse_known_args()
 
 print("Arguments:")
@@ -55,8 +56,8 @@ print(json.dumps(input_config, indent=4))
 job = transformerlab.plugin.Job(config["job_id"])
 job.update_progress(0)
 
-model_name = config['model_name']
-adaptor_output_dir = config['adaptor_output_dir']
+model_name = config["model_name"]
+adaptor_output_dir = config["adaptor_output_dir"]
 
 lora_layers = config.get("lora_layers", 1)
 learning_rate = config["learning_rate"]
@@ -65,11 +66,11 @@ steps_per_eval = config.get("steps_per_eval", 200)
 iters = config.get("iters", -1)
 
 # we need to adapter parameter so set a default
-adaptor_name = config.get('adaptor_name', "default")
+adaptor_name = config.get("adaptor_name", "default")
 
 preference_strategy = config.get("pref_loss", "dpo")
-if preference_strategy == 'dpo':
-    preference_strategy = 'sigmoid'  # llama factory calls dpo "sigmoid"
+if preference_strategy == "dpo":
+    preference_strategy = "sigmoid"  # llama factory calls dpo "sigmoid"
 if preference_strategy not in ["sigmoid", "orpo", "simpo"]:
     print("Invalid preference strategy")
     job.set_job_completion_status("failed", "Invalid preference strategy")
@@ -92,11 +93,7 @@ def create_data_directory_in_llama_factory_format():
             "file_name": "train.json",
             "ranking": True,
             "formatting": "sharegpt",
-            "columns": {
-                "messages": "conversations",
-                "chosen": "chosen",
-                "rejected": "rejected"
-            }
+            "columns": {"messages": "conversations", "chosen": "chosen", "rejected": "rejected"},
         }
     }
 
@@ -109,8 +106,7 @@ def create_data_directory_in_llama_factory_format():
 ########################################
 
 try:
-    dataset_target = transformerlab.plugin.get_dataset_path(
-        config["dataset_name"])
+    dataset_target = transformerlab.plugin.get_dataset_path(config["dataset_name"])
 except Exception as e:
     job.set_job_completion_status("failed", "failed to get dataset path")
     raise e
@@ -126,7 +122,7 @@ except Exception as e:
 try:
     with open(f"{data_directory}/train.json", "w") as f:
         all_data = []
-        for row in dataset['train']:
+        for row in dataset["train"]:
             all_data.append(row)
         json.dump(all_data, f, indent=2)
 except Exception as e:
@@ -144,12 +140,11 @@ print(f"Storing Tensorboard Output to: {output_dir}")
 
 
 # First copy a template file to the data directory
-os.system(
-    f"cp {plugin_dir}/LLaMA-Factory/examples/train_lora/llama3_lora_dpo.yaml {yaml_config_path}")
+os.system(f"cp {plugin_dir}/LLaMA-Factory/examples/train_lora/llama3_lora_dpo.yaml {yaml_config_path}")
 # Now replace specific values in the file using the PyYAML library:
 
 yml = {}
-with open(yaml_config_path, 'r') as file:
+with open(yaml_config_path, "r") as file:
     yml = yaml.safe_load(file)
 
 try:
@@ -161,21 +156,21 @@ except Exception as e:
 
 print("Template configuration:")
 print(yml)
-yml['pref_loss'] = preference_strategy
+yml["pref_loss"] = preference_strategy
 yml["model_name_or_path"] = model_name
 yml["output_dir"] = adaptor_output_dir
 yml["logging_dir"] = output_dir
 yml["learning_rate"] = float(config.get("learning_rate", 0.001))
 yml["num_train_epochs"] = float(config.get("num_train_epochs", 1))
 yml["max_steps"] = float(config.get("max_steps", -1))
-yml['dataset_dir'] = data_directory
-yml['dataset'] = 'training_data'
-yml['template'] = 'llama3'
+yml["dataset_dir"] = data_directory
+yml["dataset"] = "training_data"
+yml["template"] = "llama3"
 # Without resize_vocab the training fails for many models including Mistral
-yml['resize_vocab'] = True
+yml["resize_vocab"] = True
 print("--------")
 
-with open(yaml_config_path, 'w') as file:
+with open(yaml_config_path, "w") as file:
     # Now write out the new file
     yaml.dump(yml, file)
     print("New configuration:")
@@ -188,7 +183,7 @@ with open(yaml_config_path, 'w') as file:
 ########################################
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-popen_command = ['llamafactory-cli', 'train', yaml_config_path]
+popen_command = ["llamafactory-cli", "train", yaml_config_path]
 
 print("Running command:")
 print(popen_command)
@@ -203,14 +198,19 @@ print("Training beginning:")
 error_output = ""
 
 with subprocess.Popen(
-        popen_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, universal_newlines=True, cwd=os.path.join(plugin_dir, 'LLaMA-Factory')) as process:
-
+    popen_command,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    bufsize=1,
+    universal_newlines=True,
+    cwd=os.path.join(plugin_dir, "LLaMA-Factory"),
+) as process:
     training_step_has_started = False
 
     for line in process.stdout:
         error_output += line
 
-        if job.should_stop:
+        if job.should_stop():
             print("Stopping job because of user interruption.")
             job.update_status("STOPPED")
             job.set_job_completion_status("failed", "user stopped the job")
@@ -224,7 +224,7 @@ with subprocess.Popen(
 
         # Each output line from lora.py looks like
         # "  2%|▏         | 8/366 [00:15<11:28,  1.92s/it]"
-        pattern = r'(\d+)%\|.*\| (\d+)\/(\d+) \[(\d+):(\d+)<(\d+):(\d+),(\s*)(\d+\.\d+)(.+)]'
+        pattern = r"(\d+)%\|.*\| (\d+)\/(\d+) \[(\d+):(\d+)<(\d+):(\d+),(\s*)(\d+\.\d+)(.+)]"
         match = re.search(pattern, line)
         if match:
             percentage = match.group(1)
@@ -235,14 +235,18 @@ with subprocess.Popen(
             it_s = match.group(8)
 
             print(
-                f"Percentage: {percentage}, Current: {current}, Total: {total}, Minutes: {minutes}, Seconds: {seconds}, It/s: {it_s}")
+                f"Percentage: {percentage}, Current: {current}, Total: {total}, Minutes: {minutes}, Seconds: {seconds}, It/s: {it_s}"
+            )
             job.update_progress(percentage)
 
         print(line, end="", flush=True)
 
     return_code = process.wait()
 
-    if return_code!=0 and "TypeError: DPOTrainer.create_model_card() got an unexpected keyword argument 'license'" not in error_output:
+    if (
+        return_code != 0
+        and "TypeError: DPOTrainer.create_model_card() got an unexpected keyword argument 'license'" not in error_output
+    ):
         job.set_job_completion_status("failed", "failed during training")
         raise RuntimeError(f"Training failed: {error_output}")
 
@@ -252,7 +256,7 @@ print("Finished training.")
 
 print("Now fusing the adaptor with the model.")
 
-model_name = config['model_name']
+model_name = config["model_name"]
 if "/" in model_name:
     model_name = model_name.split("/")[-1]
 fused_model_name = f"{model_name}_{adaptor_name}"
@@ -264,26 +268,26 @@ if not os.path.exists(fused_model_location):
 
 yaml_config_path = f"{data_directory}/merge_llama3_lora_sft.yaml"
 # First copy a template file to the data directory
-os.system(
-    f"cp {plugin_dir}/LLaMA-Factory/examples/merge_lora/llama3_lora_sft.yaml {yaml_config_path}")
+os.system(f"cp {plugin_dir}/LLaMA-Factory/examples/merge_lora/llama3_lora_sft.yaml {yaml_config_path}")
 yml = {}
-with open(yaml_config_path, 'r') as file:
+with open(yaml_config_path, "r") as file:
     yml = yaml.safe_load(file)
 
-yml["model_name_or_path"] = config['model_name']
+yml["model_name_or_path"] = config["model_name"]
 yml["adapter_name_or_path"] = adaptor_output_dir
 yml["export_dir"] = fused_model_location
 yml["resize_vocab"] = True
 
-with open(yaml_config_path, 'w') as file:
+with open(yaml_config_path, "w") as file:
     yaml.dump(yml, file)
     print("New configuration:")
     print(yml)
 
-fuse_popen_command = ['llamafactory-cli', 'export', yaml_config_path]
+fuse_popen_command = ["llamafactory-cli", "export", yaml_config_path]
 
 with subprocess.Popen(
-        fuse_popen_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, universal_newlines=True) as process:
+    fuse_popen_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, universal_newlines=True
+) as process:
     for line in process.stdout:
         print(line, end="", flush=True)
 
@@ -291,20 +295,22 @@ with subprocess.Popen(
 
     # If model create was successful, create an info.json file so this can be read by the system
     print("Return code: ", return_code)
-    if (return_code == 0):
-        model_description = [{
-            "model_id": f"TransformerLab/{fused_model_name}",
-            "model_filename": "",
-            "name": fused_model_name,
-            "local_model": True,
-            "json_data": {
-                "uniqueID": f"TransformerLab/{fused_model_name}",
-                "name": "dpo_orpo_simpo_trainer_llama_factory",
-                "description": f"Model generated using Llama Factory in TransformerLab based on {config['model_name']}",
-                "architecture": config["model_architecture"],
-                "huggingface_repo": ""
+    if return_code == 0:
+        model_description = [
+            {
+                "model_id": f"TransformerLab/{fused_model_name}",
+                "model_filename": "",
+                "name": fused_model_name,
+                "local_model": True,
+                "json_data": {
+                    "uniqueID": f"TransformerLab/{fused_model_name}",
+                    "name": "dpo_orpo_simpo_trainer_llama_factory",
+                    "description": f"Model generated using Llama Factory in TransformerLab based on {config['model_name']}",
+                    "architecture": config["model_architecture"],
+                    "huggingface_repo": "",
+                },
             }
-        }]
+        ]
         model_description_file = open(f"{fused_model_location}/info.json", "w")
         json.dump(model_description, model_description_file)
         model_description_file.close()

--- a/transformerlab/plugins/eleuther-ai-lm-evaluation-harness-mlx/main.py
+++ b/transformerlab/plugins/eleuther-ai-lm-evaluation-harness-mlx/main.py
@@ -136,7 +136,7 @@ try:
                     if metric and value:
                         scores_list.append({"type": f"{metric}", "score": value})
 
-                    if job.should_stop:
+                    if job.should_stop():
                         print("Stopping job because of user interruption.")
                         job.update_status("STOPPED")
                         process.terminate()

--- a/transformerlab/plugins/eleuther-ai-lm-evaluation-harness/main.py
+++ b/transformerlab/plugins/eleuther-ai-lm-evaluation-harness/main.py
@@ -149,7 +149,7 @@ try:
             if metric and value:
                 scores_list.append({"type": f"{metric}", "score": value})
 
-            if job.should_stop:
+            if job.should_stop():
                 print("Stopping job because of user interruption.")
                 job.update_status("STOPPED")
                 process.terminate()

--- a/transformerlab/plugins/llama_trainer/main.py
+++ b/transformerlab/plugins/llama_trainer/main.py
@@ -159,7 +159,7 @@ args = SFTConfig(
     tf32=True,
     max_grad_norm=0.3,
     warmup_ratio=0.03,
-    lr_scheduler_type=config.get("learning_rate_schedule","constant"),
+    lr_scheduler_type=config.get("learning_rate_schedule", "constant"),
     max_seq_length=max_seq_length,
     disable_tqdm=False,  # disable tqdm since with packing values are in correct
     packing=True,
@@ -183,7 +183,7 @@ class ProgressTableUpdateCallback(TrainerCallback):
             # Write to jobs table in database, updating the
             # progress column:
             job.update_progress(progress)
-            if job.should_stop:
+            if job.should_stop():
                 control.should_training_stop = True
                 return control
 

--- a/transformerlab/plugins/mlx_lora_trainer/main.py
+++ b/transformerlab/plugins/mlx_lora_trainer/main.py
@@ -282,7 +282,7 @@ with subprocess.Popen(
             # print(percent_complete, ' ', config["job_id"])
             job.update_progress(percent_complete)
 
-            if job.should_stop:
+            if job.should_stop():
                 print("Stopping job because of user interruption.")
                 job.update_status("STOPPED")
                 process.terminate()

--- a/transformerlab/plugins/sft_llama_factory/main.py
+++ b/transformerlab/plugins/sft_llama_factory/main.py
@@ -227,7 +227,7 @@ with subprocess.Popen(
                 f"Percentage: {percentage}, Current: {current}, Total: {total}, Minutes: {minutes}, Seconds: {seconds}, It/s: {it_s}"
             )
             job.update_progress(percentage)
-            if job.should_stop:
+            if job.should_stop():
                 print("Stopping job because of user interruption.")
                 job.update_status("STOPPED")
                 process.terminate()


### PR DESCRIPTION
Features Added:

1) Kill download process for huggingface models when a stop job command is sent for cancelling downloads.
2) Delete models from Huggingface Cache - both partially downloaded and models that are deleted
3) Updated Job class to contain a should_stop() method that can determine if a stop command is sent. 

Routes Updated:

1) /model/delete - added one boolean argument 'delete_from_cache' that determines whether to delete the model from cache or not when dlete model command is sent. 

