### PR TITLE
Critical Ollama plugin and import fixes

### DIFF
--- a/transformerlab/models/ollamamodel.py
+++ b/transformerlab/models/ollamamodel.py
@@ -65,6 +65,10 @@ class OllamaModel(basemodel.BaseModel):
         super().__init__(ollama_id)
 
         self.source = "ollama"
+        if variant == "latest":
+            self.name = model_name
+        else:
+            self.name = f"{model_name} {variant}"
 
         # Make sure the source ID explicitly contains the variant name
         # It's OK if the display name doesn't have a variant but we need it
@@ -157,9 +161,9 @@ class OllamaModel(basemodel.BaseModel):
         # Most models in ollama will not have the gguf part.
         file_name, file_extension = os.path.splitext(output_model_name)
         if file_extension == ".gguf":
-            output_model_id = self.id
+            output_model_id = output_model_name
         else:
-            output_model_id = f"{self.id}.gguf"
+            output_model_id = f"{output_model_name}.gguf"
 
         # Model filename and model name should be the same
         output_filename = output_model_id

--- a/transformerlab/models/ollamamodel.py
+++ b/transformerlab/models/ollamamodel.py
@@ -15,7 +15,9 @@ from transformerlab.shared import dirs
 async def list_models():
     try:
         ollama_model_library = ollama_models_library_dir()
-    except Exception:
+    except Exception as e:
+        print("Failed to locate Ollama models library:")
+        print(str(e))
         return []
 
     models = []

--- a/transformerlab/models/ollamamodel.py
+++ b/transformerlab/models/ollamamodel.py
@@ -50,7 +50,6 @@ class OllamaModel(basemodel.BaseModel):
         self.source = "ollama"
         self.source_id_or_path = ollama_id
         self.model_filename = self._get_model_blob_filename()
-        print(self.model_filename)
 
     def _get_model_blob_filename(self):
         """

--- a/transformerlab/plugins/ollama_server/main.py
+++ b/transformerlab/plugins/ollama_server/main.py
@@ -150,7 +150,7 @@ class OllamaServer(BaseModelWorker):
 
         # 2b. Create a link with the SHA name to the actual GGUF file
         OLLAMA_MODEL_BLOBS_CACHE = os.path.join(OLLAMA_MODELS_DIR, "blobs")
-        sha_filename = os.path.join(OLLAMA_MODEL_BLOBS_CACHE, f"sha256:{sha256sum.hexdigest()}")
+        sha_filename = os.path.join(OLLAMA_MODEL_BLOBS_CACHE, f"sha256-{sha256sum.hexdigest()}")
 
         # Create the directory if it doesn't exist
         os.makedirs(OLLAMA_MODEL_BLOBS_CACHE, exist_ok=True)
@@ -427,8 +427,9 @@ async def api_model_details(request: Request):
 def cleanup_at_exit():
     global worker
     print("Cleaning up...")
-    worker.stop_server()
-    del worker
+    if worker:
+        worker.stop_server()
+        del worker
 
 
 atexit.register(cleanup_at_exit)

--- a/transformerlab/plugins/ollama_server/main.py
+++ b/transformerlab/plugins/ollama_server/main.py
@@ -127,8 +127,19 @@ class OllamaServer(BaseModelWorker):
         # Split model_path into the directory and filename
         model_dir, model_filename = os.path.split(model_path)
 
-        # Our convention is that GGUF models have the same name as their filename
-        self.model_name = model_filename
+        # This is the name that the model will be known by in ollama
+        # We will use the same name as in Transformer Lab but with .gguf on the end. 
+        #
+        # Explanation:
+        # We can call models whatever we want in Ollama, but they will be visible 
+        # to the user. So keeping in mind that we also support importing Ollama models
+        # we really don't want to create unnecessary duplicate models with the same 
+        # name but with .gguf on the end.
+        file_name, file_extension = os.path.splitext(model_filename)
+        if file_extension == ".gguf":
+            self.ollama_model_name = file_name  # i.e. without .gguf
+        else:
+            self.ollama_model_name = model_filename
 
         # Output a modelfile
         modelfile = os.path.join(model_dir, "Modelfile")
@@ -163,12 +174,12 @@ class OllamaServer(BaseModelWorker):
         # STEP 3: Call ollama and tell it to create the model in its register
         # TODO: I think you can do this via the SDK which would be better
         # for catching errors
-        subprocess.run(["ollama", "create", self.model_name, "-f", modelfile])
+        subprocess.run(["ollama", "create", self.ollama_model_name, "-f", modelfile])
 
         # STEP 4: Start the model!
         # You load a model into memory in ollama by not passing a prompt to model.generate
         load_model = self.model.generate(
-            model=self.model_name,
+            model=self.ollama_model_name,
         )
         print(load_model)
 
@@ -180,7 +191,7 @@ class OllamaServer(BaseModelWorker):
         # You can try pulling this from modelinfo from ollama.show
         # As a backup, we will assume ollama default of 4096
         self.context_len = 4096
-        show_response: ollama.ShowResponse = ollama.show(model=self.model_name)
+        show_response: ollama.ShowResponse = ollama.show(model=self.ollama_model_name)
         modelinfo = show_response.modelinfo
         print(modelinfo)
         model_architecture = modelinfo.get("general.architecture", None)
@@ -261,7 +272,7 @@ class OllamaServer(BaseModelWorker):
         # TODO: Should this use generate?
         iterator = await run_in_threadpool(
             self.model.chat,
-            model=self.model_name,
+            model=self.ollama_model_name,
             messages=[{"role": "user", "content": context}],
             stream=True,
             options=generation_params,
@@ -334,7 +345,7 @@ class OllamaServer(BaseModelWorker):
 
         print("Generating with params: ", params)
         thread = asyncio.to_thread(
-            self.model.generate, model=self.model_name, prompt=prompt, stream=False, options=params
+            self.model.generate, model=self.ollama_model_name, prompt=prompt, stream=False, options=params
         )
 
         response = await thread
@@ -354,7 +365,7 @@ class OllamaServer(BaseModelWorker):
         """
         # You can unload a model by not passing a prompt to generate
         # and setting keep_alive to 0
-        self.model.generate(model=self.model_name, keep_alive=0)
+        self.model.generate(model=self.ollama_model_name, keep_alive=0)
 
 
 def release_worker_semaphore():


### PR DESCRIPTION
Updated the way we name and identify ollama models because:
- Need to support variants of the same model
- Prevent cruft if models are passed back and forth between Ollama and Transformer Lab
- Try to present a consistent view to the user in each application

Half of this PR is just comments to explain in the code.
