### PR TITLE
Potential fix for code scanning alert no. 29: Full server-side request forgery

### DIFF
--- a/transformerlab/plugins/mlx_vlm_server/main.py
+++ b/transformerlab/plugins/mlx_vlm_server/main.py
@@ -94,8 +94,12 @@ class MLXWorker(BaseModelWorker):
                 image_data = base64.b64decode(image_link[base64_str_index:])
                 image = Image.open(BytesIO(image_data))
             else:
-                response = requests.get(image_link)
-                image = Image.open(BytesIO(response.content))
+                authorized_domains = ["example.com", "trusted.com"]
+                if any(image_link.startswith(f"https://{domain}") for domain in authorized_domains):
+                    response = requests.get(image_link)
+                    image = Image.open(BytesIO(response.content))
+                else:
+                    raise ValueError("Unauthorized image link domain")
         # Extract messages from the prompt
         prompt = params["prompt"]
 


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/29](https://github.com/transformerlab/transformerlab-api/security/code-scanning/29)

To fix the SSRF vulnerability, we need to validate the `image_link` parameter to ensure it only allows URLs from trusted domains. This can be achieved by maintaining a list of authorized domains and checking if the `image_link` belongs to one of these domains before making the HTTP request.

1. Create a list of authorized domains.
2. Validate the `image_link` to ensure it belongs to one of the authorized domains.
3. If the `image_link` is not valid, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
