### PR TITLE
Potential fix for code scanning alert no. 101: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/experiment/export.py
+++ b/transformerlab/routers/experiment/export.py
@@ -109,10 +109,10 @@ async def run_exporter_script(id: int, plugin_name: str, plugin_architecture: st
             python_script=subprocess_command, job_id=job_id, begin_string="Exporting"
         )
     except Exception as e:
-        fail_msg = f"Failed to export model. Exception: {e}"
+        import logging
+        logging.error(f"Failed to export model. Exception: {e}")
         await db.job_update_status(job_id=job_id, status="FAILED")
-        print(fail_msg)
-        return {"message": fail_msg}
+        return {"message": "Failed to export model due to an internal error."}
 
     if process.returncode != 0:
         fail_msg = f"Failed to export model. Return code: {process.returncode}"


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/101](https://github.com/transformerlab/transformerlab-api/security/code-scanning/101)

To fix the problem, we should avoid returning the detailed exception message to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This way, developers can still access the detailed error information for debugging purposes, but users will not see any sensitive information.

- Modify the code to log the detailed exception message using a logging library.
- Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
