### PR TITLE
Potential fix for code scanning alert no. 102: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/jobs.py
+++ b/transformerlab/routers/jobs.py
@@ -2,6 +2,7 @@ import json
 import os
 import csv
 import pandas as pd
+import logging
 from fastapi import APIRouter, Body, Response
 from fastapi.responses import StreamingResponse, FileResponse
 
@@ -143,9 +144,11 @@ async def update_training_template(
         datasets = configObject["dataset_name"]
         await db.update_training_template(template_id, name, description, type, datasets, config)
     except JSONDecodeError as e:
-        return {"status": "error", "message": str(e)}
+        logging.error(f"JSON decode error: {e}")
+        return {"status": "error", "message": "An error occurred while processing the request."}
     except Exception as e:
-        return {"status": "error", "message": str(e)}
+        logging.error(f"Unexpected error: {e}")
+        return {"status": "error", "message": "An internal error has occurred."}
     return {"status": "success"}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/102](https://github.com/transformerlab/transformerlab-api/security/code-scanning/102)

To fix the problem, we need to ensure that detailed error messages, including stack traces, are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the current exception handling code to log the detailed error message and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
