### PR TITLE
Potential fix for code scanning alert no. 103: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/jobs.py
+++ b/transformerlab/routers/jobs.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import csv
 import pandas as pd
@@ -143,9 +144,11 @@ async def update_training_template(
         datasets = configObject["dataset_name"]
         await db.update_training_template(template_id, name, description, type, datasets, config)
     except JSONDecodeError as e:
-        return {"status": "error", "message": str(e)}
+        logging.error(f"JSON decode error: {str(e)}")
+        return {"status": "error", "message": "An internal error has occurred!"}
     except Exception as e:
-        return {"status": "error", "message": str(e)}
+        logging.error(f"Unexpected error: {str(e)}")
+        return {"status": "error", "message": "An internal error has occurred!"}
     return {"status": "success"}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/103](https://github.com/transformerlab/transformerlab-api/security/code-scanning/103)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the current return statements in the exception handling blocks with logging statements and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
