### PR TITLE
Potential fix for code scanning alert no. 104: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -12,8 +12,8 @@ from huggingface_hub import ModelCard, ModelCardData
 from huggingface_hub.utils import HfHubHTTPError
 import os
 from pathlib import Path
-
-
+import logging
+logging.basicConfig(level=logging.ERROR)
 from transformerlab.shared import shared
 from transformerlab.shared import dirs
 from transformerlab.shared import galleries
@@ -169,7 +169,8 @@ async def upload_model_to_huggingface(
         elif organization_name in orgs and organization_name != "":
             username = organization_name
     except Exception as e:
-        return {"status": "error", "message": f"Error getting Hugging Face user info: {e}"}
+        logging.error(f"Error getting Hugging Face user info: {e}")
+        return {"status": "error", "message": "An internal error has occurred while getting Hugging Face user info."}
     repo_id = f"{username}/{model_name}"
     try:  # Checking if repo already exists.
         api.repo_info(repo_id)


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/104](https://github.com/transformerlab/transformerlab-api/security/code-scanning/104)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

Specifically, we will:
1. Import the `logging` module to enable logging of exceptions.
2. Replace the return statement in the exception handling block with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
