### PR TITLE
Potential fix for code scanning alert no. 105: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -12,7 +12,9 @@ from huggingface_hub import ModelCard, ModelCardData
 from huggingface_hub.utils import HfHubHTTPError
 import os
 from pathlib import Path
+import logging
 
+logging.basicConfig(level=logging.ERROR)
 
 from transformerlab.shared import shared
 from transformerlab.shared import dirs
@@ -169,7 +171,8 @@ async def upload_model_to_huggingface(
         elif organization_name in orgs and organization_name != "":
             username = organization_name
     except Exception as e:
-        return {"status": "error", "message": f"Error getting Hugging Face user info: {e}"}
+        logging.error(f"Error getting Hugging Face user info: {e}")
+        return {"status": "error", "message": "An internal error has occurred while getting user info."}
     repo_id = f"{username}/{model_name}"
     try:  # Checking if repo already exists.
         api.repo_info(repo_id)
@@ -179,7 +182,8 @@ async def upload_model_to_huggingface(
             # Should we add a toggle for them to allow private repos?
             create_repo(repo_id)
         else:
-            return {"status": "error", "message": f"Error creating Hugging Face repo: {e}"}
+            logging.error(f"Error creating Hugging Face repo: {e}")
+            return {"status": "error", "message": "An internal error has occurred while creating the repo."}
 
     # Upload regardless in case they want to make changes/add to to an existing repo.
     upload_folder(folder_path=model_directory, repo_id=repo_id)


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/105](https://github.com/transformerlab/transformerlab-api/security/code-scanning/105)

To fix the problem, we need to ensure that detailed exception messages are not exposed to end users. Instead, we should log the detailed error message on the server side and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the return statement that exposes the exception message with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
