### PR TITLE
Potential fix for code scanning alert no. 108: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -457,8 +457,10 @@ async def download_huggingface_model(hugging_face_id: str, model_details: str = 
 
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
-        await db.job_update_status(job_id, "FAILED", error_msg)
-        return {"status": "error", "message": error_msg}
+        # Log the detailed error message
+        print(error_msg)  # Replace with appropriate logging mechanism
+        await db.job_update_status(job_id, "FAILED", "An internal error has occurred.")
+        return {"status": "error", "message": "An internal error has occurred."}
 
     except asyncio.CancelledError:
         error_msg = "Download cancelled"
@@ -486,7 +488,9 @@ async def download_model_by_huggingface_id(model: str, job_id: int | None = None
         model_details = await huggingfacemodel.get_model_details_from_huggingface(model)
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
-        return {"status": "error", "message": error_msg}
+        # Log the detailed error message
+        print(error_msg)  # Replace with appropriate logging mechanism
+        return {"status": "error", "message": "An internal error has occurred."}
 
     if model_details is None:
         error_msg = f"Error reading config for model with ID {model}"


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/108](https://github.com/transformerlab/transformerlab-api/security/code-scanning/108)

To fix the problem, we need to ensure that detailed exception messages are not returned to the user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the error and return a generic message.

1. Modify the exception handling in the `download_huggingface_model` function to log the detailed error message and return a generic error message.
2. Modify the exception handling in the `download_model_by_huggingface_id` function to log the detailed error message and return a generic error message.
3. Ensure that the logging mechanism is in place to capture the detailed error messages for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
