### PR TITLE
Potential fix for code scanning alert no. 113: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/train.py
+++ b/transformerlab/routers/train.py
@@ -76,7 +76,7 @@ async def import_recipe(name: str, recipe_yaml: str = Body(...)):
         recipe = yaml.safe_load(recipe_yaml)
     except yaml.YAMLError as e:
         print(e)
-        return {"status": "error", "message": e}
+        return {"status": "error", "message": "An error occurred while processing the recipe."}
 
     # Get top level sections of recipe
     # TODO: Is it an error if any of these don't exist?


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/113](https://github.com/transformerlab/transformerlab-api/security/code-scanning/113)

To fix the problem, we should avoid sending the exception message directly to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the exception handling block to log the exception message instead of returning it.
- Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
