### PR TITLE
Potential fix for code scanning alert no. 110: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -713,8 +713,8 @@ def import_error(message: str):
     """
     Separate function just to factor out printing and returning the same error.
     """
-    print("Import error:", message)
-    return {"status": "error", "message": str(message)}
+    logging.error("Import error: %s", message)
+    return {"status": "error", "message": "An internal error has occurred. Please try again later."}
 
 
 async def model_import(model: basemodel.BaseModel):


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/110](https://github.com/transformerlab/transformerlab-api/security/code-scanning/110)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by modifying the `import_error` function to log the detailed error message and return a generic message.

1. Modify the `import_error` function in `transformerlab/routers/model.py` to log the detailed error message and return a generic error message.
2. Ensure that the logging configuration is set up to capture these logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
