### PR TITLE
Potential fix for code scanning alert no. 168: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/data.py
+++ b/transformerlab/routers/data.py
@@ -17,9 +17,12 @@ from werkzeug.utils import secure_filename
 
 from jinja2 import Environment
 from jinja2.sandbox import SandboxedEnvironment
+import logging
 
 jinja_environment = Environment()
 sandboxed_jinja2_evironment = SandboxedEnvironment()
+
+logging.basicConfig(level=logging.ERROR)
 
 
 # Configure logging
@@ -145,8 +148,8 @@ async def dataset_preview(
             else:
                 dataset = load_dataset(dataset_id, trust_remote_code=True, streaming=streaming)
     except Exception as e:
-        error_msg = f"{type(e).__name__}: {e}"
-        return {"status": "error", "message": error_msg}
+        logging.error(f"Exception occurred: {type(e).__name__}: {e}")
+        return {"status": "error", "message": "An internal error has occurred."}
 
     if split is None or split == "":
         splits = list(dataset.keys())


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/168](https://github.com/transformerlab/transformerlab-api/security/code-scanning/168)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using a logging mechanism to record the detailed error message and modifying the response to include a generic error message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the return statement that includes the detailed error message with a logging statement and a return statement that includes a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
