### PR TITLE
Potential fix for code scanning alert no. 176: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/train.py
+++ b/transformerlab/routers/train.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body
 from fastapi.responses import PlainTextResponse, StreamingResponse
-
+import logging
 import transformerlab.db as db
 from transformerlab.routers.serverinfo import watch_file
 from transformerlab.shared import dirs
@@ -293,10 +293,12 @@ async def get_training_job_output(job_id: str):
         return output
     except ValueError as e:
         # Handle specific error
-        return f"ValueError: {e}"
+        logging.error(f"ValueError: {e}")
+        return "An internal error has occurred!"
     except Exception as e:
         # Handle general error
-        return f"Error: {e}"
+        logging.error(f"Error: {e}")
+        return "An internal error has occurred!"
 
 
 @router.get("/job/{job_id}/stream_output")
@@ -312,7 +314,8 @@ async def watch_log(job_id: str):
             print("Retrying to get output file in 4 seconds...")
             output_file_name = await get_output_file_name(job_id)
         else:
-            return f"ValueError: {e}"
+            logging.error(f"ValueError: {e}")
+            return "An internal error has occurred!"
 
     return StreamingResponse(
         # we force polling because i can't get this to work otherwise -- changes aren't detected


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/176](https://github.com/transformerlab/transformerlab-api/security/code-scanning/176)

To fix the problem, we need to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception details and return a generic error message.

1. Import the `logging` module to log the error messages.
2. Replace the current exception handling code to log the detailed error messages and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
