### PR TITLE
Potential fix for code scanning alert no. 106: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -390,8 +390,8 @@ def get_model_download_size(model_id: str, allow_patterns: list = []):
     try:
         download_size_in_bytes = huggingfacemodel.get_huggingface_download_size(model_id, allow_patterns)
     except Exception as e:
-        error_msg = f"{type(e).__name__}: {e}"
-        return {"status": "error", "message": error_msg}
+        logging.error(f"Error in get_model_download_size: {type(e).__name__}: {e}")
+        return {"status": "error", "message": "An internal error has occurred."}
 
     return {"status": "success", "data": download_size_in_bytes}
 


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/106](https://github.com/transformerlab/transformerlab-api/security/code-scanning/106)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `get_model_download_size` function.

1. Import the `logging` module if not already imported.
2. Log the detailed error message using `logging.error`.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
