### PR TITLE
Potential fix for code scanning alert no. 105: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -182,7 +182,8 @@ async def upload_model_to_huggingface(
             # Should we add a toggle for them to allow private repos?
             create_repo(repo_id)
         else:
-            return {"status": "error", "message": f"Error creating Hugging Face repo: {e}"}
+            logging.error(f"Error creating Hugging Face repo: {e}")
+            return {"status": "error", "message": "An internal error has occurred while creating Hugging Face repo."}
 
     # Upload regardless in case they want to make changes/add to to an existing repo.
     upload_folder(folder_path=model_directory, repo_id=repo_id)


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/105](https://github.com/transformerlab/transformerlab-api/security/code-scanning/105)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Modify the exception handling block on line 185 to log the detailed error message.
2. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
