### PR TITLE
Potential fix for code scanning alert no. 169: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/data.py
+++ b/transformerlab/routers/data.py
@@ -200,8 +200,8 @@ async def dataset_preview_with_template(
         try:
             dataset = load_dataset(path=dirs.dataset_dir_by_id(dataset_id))
         except Exception as e:
-            error_msg = f"{type(e).__name__}: {e}"
-            return {"status": "error", "message": error_msg}
+            logging.error(f"Error loading dataset: {type(e).__name__}: {e}")
+            return {"status": "error", "message": "An internal error has occurred."}
         dataset_len = len(dataset["train"])
         result["columns"] = dataset["train"][offset : min(offset + limit, dataset_len)]
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/169](https://github.com/transformerlab/transformerlab-api/security/code-scanning/169)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the error and returning a generic error message in the response.

1. Import the `logging` module if it is not already imported.
2. Replace the current error handling code to log the detailed error message and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
