### PR TITLE
Potential fix for code scanning alert no. 172: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/tools.py
+++ b/transformerlab/routers/tools.py
@@ -107,7 +107,7 @@ async def call_tool(tool_id: str, params: str):
         print(err_string)
         print("Passed JSON parameter string:")
         print(params)
-        return {"status": "error", "message": err_string}
+        return {"status": "error", "message": "Invalid parameters provided."}
 
     try:
         tool_function = available_tools.get(tool_id)
@@ -120,4 +120,4 @@ async def call_tool(tool_id: str, params: str):
     except Exception as e:
         err_string = f"{type(e).__name__}: {e}"
         print(err_string)
-        return {"status": "error", "message": err_string}
+        return {"status": "error", "message": "An internal error has occurred."}


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/172](https://github.com/transformerlab/transformerlab-api/security/code-scanning/172)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

- Modify the exception handling code in the `call_tool` function to log the detailed error message and return a generic error message.
- Add necessary imports for logging if not already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
