### PR TITLE
Potential fix for code scanning alert no. 170: Information exposure through an exception

### DIFF
--- a/transformerlab/routers/evals.py
+++ b/transformerlab/routers/evals.py
@@ -90,5 +90,6 @@ async def compare_eval(job_list: str = ""):
         return JSONResponse(content=combined.to_json(orient="records"), media_type="application/json")
 
     except Exception as e:
-        print(e)
-        return {"error": str(e)}
+        import logging
+        logging.error("An error occurred while comparing evaluations", exc_info=True)
+        return {"error": "An internal error has occurred. Please try again later."}


### PR DESCRIPTION
Potential fix for [https://github.com/transformerlab/transformerlab-api/security/code-scanning/170](https://github.com/transformerlab/transformerlab-api/security/code-scanning/170)

To fix the problem, we should ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the exception and return a generic error message.

1. Import the `logging` module to log the detailed error message.
2. Replace the `print(e)` statement with a logging statement.
3. Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
