### PR TITLE
Fix model training, provenance, embedding trainer bug

### DIFF
--- a/transformerlab/models/localmodel.py
+++ b/transformerlab/models/localmodel.py
@@ -190,7 +190,13 @@ class LocalModelStore(modelstore.ModelStore):
                 # The configuration is stored as a JSON string inside job_data["config"]
                 config_str = job_data.get("config")
                 try:
-                    config = json.loads(config_str)
+                    if isinstance(config_str, str):
+                        # If the config is a string, parse it as JSON
+                        config = json.loads(config_str)
+                    elif isinstance(config_str, dict):
+                        # If the config is already a dictionary, use it directly
+                        config = config_str
+
                 except Exception as e:
                     print(f"Error parsing config for job id {job.get('id', 'unknown')}: {e}")
                     config = {}

--- a/transformerlab/plugin_sdk/transformerlab/sdk/v1/train.py
+++ b/transformerlab/plugin_sdk/transformerlab/sdk/v1/train.py
@@ -85,9 +85,16 @@ class TrainerTLabPlugin(TLabPlugin):
             # Load configuration from file
             with open(self.params.input_file) as json_file:
                 input_config = json.load(json_file)
-
+            
+            # Check if there is file["config"]["config"] structure
+            double_config = False
             if "config" in input_config:
-                self.params._config = input_config["config"]
+                if "config" in input_config["config"]:
+                    self.params._config = input_config["config"]["config"]
+                    self.params.outer_config = input_config["config"]
+                    double_config = True
+                else:
+                    self.params._config = input_config["config"]
             else:
                 self.params._config = input_config
 
@@ -95,6 +102,11 @@ class TrainerTLabPlugin(TLabPlugin):
             for key, value in self.params._config.items():
                 if getattr(self.params, key) is None:
                     self.params[key] = value
+            if double_config and self.params.outer_config is not None:
+                for key, value in self.params.outer_config.items():
+                    if getattr(self.params, key) is None:
+                        self.params[key] = value
+            
 
         except Exception as e:
             error_msg = f"Error loading configuration: {str(e)}\n{traceback.format_exc()}"

--- a/transformerlab/plugins/embedding_model_trainer/index.json
+++ b/transformerlab/plugins/embedding_model_trainer/index.json
@@ -137,7 +137,7 @@
         "AdaptiveLayerLoss",
         "None"
       ],
-      "default": "MatryoshkaLoss"
+      "default": "None"
     },
     "text_column_name": {
       "title": "Text Column Name",

--- a/transformerlab/plugins/embedding_model_trainer/index.json
+++ b/transformerlab/plugins/embedding_model_trainer/index.json
@@ -5,7 +5,7 @@
   "plugin-format": "python",
   "type": "trainer",
   "train_type": "embedding",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "model_architectures": [
     "BertModel",
     "SentenceTransformer",

--- a/transformerlab/plugins/embedding_model_trainer/info.md
+++ b/transformerlab/plugins/embedding_model_trainer/info.md
@@ -79,7 +79,7 @@ The **Embedding Model Trainer** plugin is designed to train or fine-tune embeddi
         - **`AdaptiveLayerLoss`**: Model performs well even when you remove model layers for faster inference.
         - **`Matryoshka2dLoss`**: Combines the above two to provide possible configurations to improve efficientcy and lower storage costs
 
-        *Note* : *The loss modifiers are attached with default configs. To modify them, kindly add the params directly in the loss modifier section of the plugin in main.py.* 
+        *Note* : *The loss modifiers are attached with default configs. To modify them, kindly add the params directly in the loss modifier section of the plugin in main.py. The MatryoshkaLoss modifiers won't work with the 'single sentences' dataset types, please select 'AdaptiveLayerLoss' or 'None' for that dataset type.* 
 
    - Adjust training parameters (number of epochs, batch size, learning rate, etc.) to suit your hardware and application requirements.
    - Enable **log_to_wandb** if you wish to track training metrics with Weights & Biases.

--- a/transformerlab/plugins/embedding_model_trainer/main.py
+++ b/transformerlab/plugins/embedding_model_trainer/main.py
@@ -222,14 +222,19 @@ def train_embedding_model():
 
     # Apply loss modifier if specified
     if loss_modifier_name != "None":
-        loss_modifier_module = __import__("sentence_transformers.losses", fromlist=[loss_modifier_name])
-        loss_modifier_cls = getattr(loss_modifier_module, loss_modifier_name)
-
-        if loss_modifier_name == "AdaptiveLayerLoss":
-            # AdaptiveLayerLoss does not take matryoshka_dims as a parameter
-            train_loss = loss_modifier_cls(model=model, loss=inner_train_loss)
+        if user_dataset_type == "single sentences":
+            print("Warning: Loss modifier is not supported for single sentences dataset type.")
+            print("Using the default loss function instead.")
+            train_loss = inner_train_loss
         else:
-            train_loss = loss_modifier_cls(model=model, loss=inner_train_loss, matryoshka_dims=matryoshka_dims)
+            loss_modifier_module = __import__("sentence_transformers.losses", fromlist=[loss_modifier_name])
+            loss_modifier_cls = getattr(loss_modifier_module, loss_modifier_name)
+
+            if loss_modifier_name == "AdaptiveLayerLoss":
+                # AdaptiveLayerLoss does not take matryoshka_dims as a parameter
+                train_loss = loss_modifier_cls(model=model, loss=inner_train_loss)
+            else:
+                train_loss = loss_modifier_cls(model=model, loss=inner_train_loss, matryoshka_dims=matryoshka_dims)
     else:
         train_loss = inner_train_loss
 
@@ -286,7 +291,8 @@ def train_embedding_model():
         }
         generate_model_json(
             final_model_name,
-            tlab_trainer.params.get("embedding_model_architecture", "BertModel"), json_data=json_data,
+            tlab_trainer.params.get("embedding_model_architecture", "BertModel"),
+            json_data=json_data,
         )
     except Exception as e:
         print(f"Warning: Failed to import model to Transformer Lab: {e}")

--- a/transformerlab/plugins/embedding_model_trainer/main.py
+++ b/transformerlab/plugins/embedding_model_trainer/main.py
@@ -286,7 +286,7 @@ def train_embedding_model():
         }
         generate_model_json(
             final_model_name,
-            tlab_trainer.params.get("embedding_model_architecture", "BertModel", json_data=json_data),
+            tlab_trainer.params.get("embedding_model_architecture", "BertModel"), json_data=json_data,
         )
     except Exception as e:
         print(f"Warning: Failed to import model to Transformer Lab: {e}")


### PR DESCRIPTION
Fixes:
- Fixes Trainer SDK to look at the second config inside the input['config']
- Fixes Model Provenance to support json coming out of the new db
- Fixes a minor bug which caused issues with saving in embedding-model-trainer
- Fixes a major bug in Embedding Model Trainer which is caused on single GPU machines if using Matryoshka loss and single sentences dataset type