### PR TITLE
Fix YourBench Plugin bugs

### DIFF
--- a/transformerlab/plugins/yourbench_data_gen/index.json
+++ b/transformerlab/plugins/yourbench_data_gen/index.json
@@ -4,7 +4,7 @@
     "description": "Generates and uploads a dataset to Huggingface with the specified configurations.",
     "plugin-format": "python",
     "type": "generator",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "git": "",
     "url": "",
     "files": [

--- a/transformerlab/plugins/yourbench_data_gen/setup.sh
+++ b/transformerlab/plugins/yourbench_data_gen/setup.sh
@@ -1,13 +1,13 @@
 # 1. Clone the repo
 git clone https://github.com/huggingface/yourbench.git
 cd yourbench
+git switch -c eb50e1fff84849e19ecb62b45a25ed6afed46a2e
 
-# Use uv to install the dependencies
-# pip install uv # if you do not have uv already
-# uv venv
-# source .venv/bin/activate
-# uv sync
+
+uv venv
+source .venv/bin/activate
+uv sync
 uv pip install -e .
-# Need this to keep the current versions and preserve my sanity
+# Need this to keep the current versions and preserve sanity
 uv pip install torch==2.6.0 --upgrade
 uv pip install textstat evaluate


### PR DESCRIPTION
- Bringing back the venv thing here, as it doesn't work without that on a clean install
- Adding a switch to a specific commit post which YourBench started withdrawing support for Python 3.11