### PR TITLE
fix: remove use of deprecated `torch.norm`

### DIFF
--- a/transformerlab/plugins/fastchat_server/model_worker.py
+++ b/transformerlab/plugins/fastchat_server/model_worker.py
@@ -542,7 +542,7 @@ def process_mlp_activations(hidden_states):
     if activations.dtype == torch.bfloat16:
         activations = activations.float()
     # Use L2 norm as the aggregation method
-    return torch.norm(activations, p=2, dim=-1).cpu().numpy()
+    return torch.linalg.vector_norm(activations, ord=2, dim=-1).cpu().numpy()
 
 
 def compute_attention_entropy(attentions):


### PR DESCRIPTION
`torch.norm` has been deprecated for quite a while now. This fixes it 👍 

See: https://pytorch.org/docs/stable/generated/torch.norm.html