### PR TITLE
Fixed: GPU did not access : GPU shows NaN

### DIFF
--- a/transformerlab/routers/serverinfo.py
+++ b/transformerlab/routers/serverinfo.py
@@ -150,7 +150,7 @@ async def get_computer_information():
 
             # check if device_name is a byte string, if so convert to string:
             if isinstance(device_name, bytes):
-                device_name = device_name.decode()
+                device_name = device_name.decode(errors="ignore")
 
             info["name"] = device_name
 


### PR DESCRIPTION
## Issue
GPU was not accessed: GPU shows NaN on the dashboard. Refer to the below issue
https://github.com/transformerlab/transformerlab-app/issues/381

## Analysis and findings

Server information was extracted in the `/info` endpoint, attached to the `get_computer_information` controller.
Server information was extracted using the `pynvml` library. 
At line 148, the device name is extracted, and it is represented as a byte string.
In the decoding process, an exception has been thrown 
`'utf-8' codec can't decode byte 0xf8 in position 0: invalid start byte`
Due to the exception handler, the line jumps to the catch block, appending the GPU information as 

```
g.append(
            {
                "name": "cpu",
                "total_memory": "n/a",
                "free_memory": "n/a",
                "used_memory": "n/a",
                "utilization": "n/a",
            }
        )
```

## Solution
Ignore errors form using `device_name = device_name.decode(errors="ignore")` 

## Sivierity 
This is just for displaying information on the dashboard and is not tied to internal modules; `ignoring errors` would be a better solution.  

![image](https://github.com/user-attachments/assets/79ebd30b-9d2e-4815-a10e-7d8fcaf56d72)



