### PR TITLE
Fix `FutureWarning` about using resume_download with Huggingface

### DIFF
--- a/transformerlab/shared/download_huggingface_model.py
+++ b/transformerlab/shared/download_huggingface_model.py
@@ -169,7 +169,7 @@ def download_blocking(model_is_downloaded):
             f.write(json.dumps(info, indent=2))
     else:
         try:
-            snapshot_download(repo_id=model, resume_download=True, allow_patterns=allow_patterns)
+            snapshot_download(repo_id=model, allow_patterns=allow_patterns)
 
         except GatedRepoError:
             returncode = 77

--- a/transformerlab/shared/download_huggingface_model.py
+++ b/transformerlab/shared/download_huggingface_model.py
@@ -145,7 +145,6 @@ def download_blocking(model_is_downloaded):
         hf_hub_download(
             repo_id=model,
             filename=model_filename,
-            resume_download=True,
             local_dir=location,
             local_dir_use_symlinks=True,
         )


### PR DESCRIPTION
FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.