### PR TITLE
Changes to FastChat and vLLM to work with custom dtypes

### DIFF
--- a/transformerlab/plugins/fastchat_server/index.json
+++ b/transformerlab/plugins/fastchat_server/index.json
@@ -51,6 +51,7 @@
       "title": "Select a specific data type for the model",
       "type": "string",
       "enum": [
+        "auto",
         "float16",
         "bfloat16",
         "float32"

--- a/transformerlab/plugins/fastchat_server/index.json
+++ b/transformerlab/plugins/fastchat_server/index.json
@@ -4,7 +4,7 @@
   "description": "Fastchat loads models for inference using Huggingface Transformers for generation.",
   "plugin-format": "python",
   "type": "loader",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "supports": ["chat", "completion", "visualize_model", "model_layers", "rag", "tools", "template", "embeddings", "tokenize", "logprobs", "batched"],
   "model_architectures": [
     "CohereForCausalLM",
@@ -46,11 +46,23 @@
       "title": "Enable 8-bit compression",
       "type": "boolean",
       "default": false
+    },
+    "model_dtype": {
+      "title": "Select a specific data type for the model",
+      "type": "string",
+      "enum": [
+        "float16",
+        "bfloat16",
+        "float32"
+      ]
     }
   },
   "parameters_ui": {
     "gpu_ids": {
       "ui:help": "Specify a comma-separated list of GPU IDs to use for inference. The IDs for each GPU can be found in the Computer tab. For example: 0,1,2,3"
+    },
+    "model_dtype": {
+      "ui:help": "Select a specific data type for the model. This might help with older GPUs that do not support bfloat16"
     }
   }
 }

--- a/transformerlab/plugins/fastchat_server/main.py
+++ b/transformerlab/plugins/fastchat_server/main.py
@@ -83,6 +83,11 @@ real_plugin_dir = os.path.realpath(os.path.dirname(__file__))
 python_executable = get_python_executable(real_plugin_dir)
 
 popen_args = [python_executable, f"{PLUGIN_DIR}/model_worker.py", "--model-path", model, "--device", device]
+
+model_dtype = parameters.get("model_dtype")
+# Set model dtype if provided
+if model_dtype is not None and model_dtype != "":
+    popen_args.extend(["--dtype", model_dtype])
 if num_gpus:
     popen_args.extend(["--gpus", gpu_ids])
     popen_args.extend(["--num-gpus", str(num_gpus)])

--- a/transformerlab/plugins/fastchat_server/main.py
+++ b/transformerlab/plugins/fastchat_server/main.py
@@ -86,7 +86,7 @@ popen_args = [python_executable, f"{PLUGIN_DIR}/model_worker.py", "--model-path"
 
 model_dtype = parameters.get("model_dtype")
 # Set model dtype if provided
-if model_dtype is not None and model_dtype != "":
+if model_dtype is not None and model_dtype != "" and model_dtype != "auto":
     popen_args.extend(["--dtype", model_dtype])
 if num_gpus:
     popen_args.extend(["--gpus", gpu_ids])

--- a/transformerlab/plugins/vllm_server/index.json
+++ b/transformerlab/plugins/vllm_server/index.json
@@ -4,7 +4,7 @@
   "description": "vLLM is a fast and easy-to-use library for LLM inference and serving.",
   "plugin-format": "python",
   "type": "loader",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "model_architectures": [
     "CohereForCausalLM",
     "FalconForCausalLM",
@@ -31,6 +31,21 @@
       "default": 0.9,
       "minimum": 0.0,
       "maximum": 1.0
+    },
+    "model_dtype": {
+      "title": "Select a specific data type for the model",
+      "type": "string",
+      "enum": [
+        "auto",
+        "float16",
+        "bfloat16",
+        "float32"
+      ]
+    }
+  },
+  "parameters_ui": {
+    "model_dtype": {
+      "ui:help": "Select a specific data type for the model. This might help with older GPUs that do not support bfloat16"
     }
   }
 }

--- a/transformerlab/plugins/vllm_server/main.py
+++ b/transformerlab/plugins/vllm_server/main.py
@@ -73,9 +73,15 @@ real_plugin_dir = os.path.realpath(os.path.dirname(__file__))
 python_executable = get_python_executable(real_plugin_dir)
 
 popen_args = [python_executable, "-m", "fastchat.serve.vllm_worker", "--model-path", model]
+model_dtype = parameters.get("model_dtype")
+# Set model dtype if provided
+if model_dtype is not None and model_dtype != "":
+    popen_args.extend(["--model_dtype", model_dtype])
 
 # Add all parameters to the command
 for key, value in parameters.items():
+    if key == "model_dtype":
+        continue
     popen_args.extend([f"--{key}", str(value)])
 
 print(popen_args)


### PR DESCRIPTION
Address transformerlab/transformerlab-app#370

- Provides options to explicitly set dtypes of models from settings in FastChat server and vLLM server
- This would enable people with pre-Ampere GPUs (such as V100 and T4) to run models which support bfloat16 and float16 but get assigned bfloat16 (on auto dtypes) due to it being more preferred  (e.g. Deepseek R1 Qwen 1.5B)
- This will help the user from the above mentioned issue to use those models within the app easily