### PR TITLE
Upgrade MLX-LM to 22.1

### DIFF
--- a/transformerlab/plugins/mlx_server/index.json
+++ b/transformerlab/plugins/mlx_server/index.json
@@ -4,8 +4,20 @@
   "description": "MLX Machine learning research on your laptop or in a data center - by Apple",
   "plugin-format": "python",
   "type": "loader",
-  "version": "0.1.30",
-  "supports": ["chat", "completion", "visualize_model", "model_layers", "rag", "tools", "template", "embeddings", "tokenize", "logprobs", "batched"],
+  "version": "0.1.31",
+  "supports": [
+    "chat",
+    "completion",
+    "visualize_model",
+    "model_layers",
+    "rag",
+    "tools",
+    "template",
+    "embeddings",
+    "tokenize",
+    "logprobs",
+    "batched"
+  ],
   "model_architectures": [
     "MLX",
     "CohereForCausalLM",
@@ -20,15 +32,12 @@
     "MixtralForCausalLM",
     "PhiForCausalLM",
     "Phi3ForCausalLM",
-    "Qwen2ForCausalLM"
+    "Qwen2ForCausalLM",
+    "Qwen3ForCausalLM",
+    "Qwen3MoeForCausalLM"
   ],
-  "supported_hardware_architectures": [
-    "mlx"
-  ],
-  "files": [
-    "main.py",
-    "setup.sh"
-  ],
+  "supported_hardware_architectures": ["mlx"],
+  "files": ["main.py", "setup.sh"],
   "setup-script": "setup.sh",
   "parameters": {}
 }

--- a/transformerlab/plugins/mlx_server/main.py
+++ b/transformerlab/plugins/mlx_server/main.py
@@ -35,7 +35,7 @@ from huggingface_hub import snapshot_download
 from mlx_embedding_models.embedding import EmbeddingModel
 from mlx_lm import load
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
-from mlx_lm.utils import generate_step
+from mlx_lm.generate import generate_step
 
 
 @asynccontextmanager

--- a/transformerlab/plugins/mlx_server/setup.sh
+++ b/transformerlab/plugins/mlx_server/setup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-uv pip install mlx==0.23.2 --upgrade
-uv pip install "mlx-lm==0.22.1" --upgrade
+uv pip install mlx==0.25.1 --upgrade
+uv pip install "mlx-lm==0.24.0" --upgrade
 uv pip install "mlx_embedding_models==0.0.11"


### PR DESCRIPTION
When we do this, we need to also upgrade our
MLX server to use the new location for generate_step which was moved in the mlx-lm lib from util.py to generate.py