### PR TITLE
Rename data gallery to prevent local local init errors

### DIFF
--- a/transformerlab/galleries/dataset-gallery.json
+++ b/transformerlab/galleries/dataset-gallery.json
@@ -60,7 +60,7 @@
     "type": "Summarization",
     "huggingfacerepo": "samsum",
     "description": "The SAMSum dataset contains about 16k messenger-like conversations with summaries. Conversations were created and written down by linguists fluent in English. Linguists were asked to create conversations similar to those they write on a daily basis, reflecting the proportion of topics of their real-life messenger convesations. The style and register are diversified - conversations could be informal, semi-formal or formal, they may contain slang words, emoticons and typos. Then, the conversations were annotated with summaries. It was assumed that summaries should be a concise brief of what people talked about in the conversation in third person. The SAMSum dataset was prepared by Samsung R&D Institute Poland and is distributed for research purposes (non-commercial licence: CC BY-NC-ND 4.0).",
-    "size": 6.5e+6,
+    "size": 6.5e6,
     "license": "GPL"
   },
   {
@@ -72,7 +72,8 @@
     "size": 20598313936,
     "license": "GPL",
     "dataset_config": "20220301.en"
-  }, {
+  },
+  {
     "id": 9,
     "name": "PKU-SafeRLHF",
     "type": "Text-Generation",
@@ -108,5 +109,4 @@
     "size": 395000,
     "license": "MIT"
   }
-
 ]


### PR DESCRIPTION
This stops messages (on-first start) like: 
```bash
❌ Unable to find local gallery file /Users/deep.gandhi/transformerlab-repos/transformerlab-api/transformerlab/galleries/dataset-gallery.json
```