### PR TITLE
Fix single file names being fetched from .tlab_markitdown

### DIFF
--- a/transformerlab/plugins/synthetic_dataset_rag/index.json
+++ b/transformerlab/plugins/synthetic_dataset_rag/index.json
@@ -1,72 +1,65 @@
 {
-    "name": "Generate Dataset with QA Pairs for RAG Evaluation",
-    "uniqueId": "synthetic_dataset_rag",
-    "description": "Generate synthetic question-answer pairs from documents for RAG system evaluation.",
-    "plugin-format": "python",
-    "type": "generator",
-    "version": "0.1.4",
-    "git": "",
-    "url": "",
-    "files": [
-        "main.py",
-        "setup.sh"
-    ],
-    "supported_hardware_architectures": [
-    "cpu",
-    "cuda",
-    "mlx"
-    ],
-    "_dataset": false,
-    "setup-script": "setup.sh",
-    "parameters": {
-        "generation_model": {
-            "title": "Generation Model (Model to be used for Generation. Select `local` to use the local model running)",
-            "type": "string"
-        },
-        "tflabcustomui_docs": {
-            "title": "Reference Documents",
-            "type": "string"
-        },
-        "chunk_size": {
-            "title": "Chunk Size",
-            "type": "integer",
-            "default": 256,
-            "minimum": 64,
-            "required": true
-        },
-        "chunk_overlap": {
-            "title": "Chunk Overlap",
-            "type": "integer",
-            "default": 200,
-            "minimum": 0,
-            "maximum": 1000,
-            "required": true
-        },
-        "n_generations": {
-            "title": "Number of QA Pairs",
-            "type": "integer",
-            "default": 10,
-            "minimum": 1,
-            "maximum": 500,
-            "required": true
-        }
+  "name": "Generate Dataset with QA Pairs for RAG Evaluation",
+  "uniqueId": "synthetic_dataset_rag",
+  "description": "Generate synthetic question-answer pairs from documents for RAG system evaluation.",
+  "plugin-format": "python",
+  "type": "generator",
+  "version": "0.1.5",
+  "git": "",
+  "url": "",
+  "files": ["main.py", "setup.sh"],
+  "supported_hardware_architectures": ["cpu", "cuda", "mlx"],
+  "_dataset": false,
+  "setup-script": "setup.sh",
+  "parameters": {
+    "generation_model": {
+      "title": "Generation Model (Model to be used for Generation. Select `local` to use the local model running)",
+      "type": "string"
     },
-    "parameters_ui": {
-        "generation_model": {
-            "ui:help": "Select the model to be used for generating QA pairs",
-            "ui:widget": "ModelProviderWidget",
-            "ui:options": {
-                "multiple": false
-            }
-        },
-        "chunk_size": {
-            "ui:help": "Size of document chunks in characters. Larger chunks provide more context but may lead to longer generation times."
-        },
-        "chunk_overlap": {
-            "ui:help": "Number of characters to overlap between chunks to maintain context continuity."
-        },
-        "n_generations": {
-            "ui:help": "Number of question-answer pairs to generate. Limited by the number of available document chunks."
-        }
+    "tflabcustomui_docs": {
+      "title": "Reference Documents",
+      "type": "string"
+    },
+    "chunk_size": {
+      "title": "Chunk Size",
+      "type": "integer",
+      "default": 256,
+      "minimum": 64,
+      "required": true
+    },
+    "chunk_overlap": {
+      "title": "Chunk Overlap",
+      "type": "integer",
+      "default": 200,
+      "minimum": 0,
+      "maximum": 1000,
+      "required": true
+    },
+    "n_generations": {
+      "title": "Number of QA Pairs",
+      "type": "integer",
+      "default": 10,
+      "minimum": 1,
+      "maximum": 500,
+      "required": true
     }
+  },
+  "parameters_ui": {
+    "generation_model": {
+      "ui:help": "Select the model to be used for generating QA pairs",
+      "ui:widget": "ModelProviderWidget",
+      "ui:options": {
+        "multiple": false
+      }
+    },
+    "chunk_size": {
+      "ui:help": "Size of document chunks in characters. Larger chunks provide more context but may lead to longer generation times."
+    },
+    "chunk_overlap": {
+      "ui:help": "Number of characters to overlap between chunks to maintain context continuity."
+    },
+    "n_generations": {
+      "ui:help": "Number of question-answer pairs to generate. Limited by the number of available document chunks."
+    }
+  }
 }

--- a/transformerlab/plugins/synthetic_dataset_rag/main.py
+++ b/transformerlab/plugins/synthetic_dataset_rag/main.py
@@ -61,6 +61,10 @@ def get_docs_list(docs: str) -> List[dict]:
                         print(f"Error reading file {file_full_path}: {e}")
         else:
             full_path = os.path.join(documents_dir, doc)
+            # Replace ending extension with .md if .tlab_markitdown is in the full_path somewhere
+            if ".tlab_markitdown" in full_path:
+                base, ext = os.path.splitext(full_path)
+                full_path = base + ".md"
             try:
                 if full_path.lower().endswith(".pdf"):
                     content = extract_text_from_pdf(full_path)


### PR DESCRIPTION
- Fixes an error which shows when you're trying to generate using only a single file and no folder and it tries to look up the file within .tlab_markitdown