### PR TITLE
Fix error of hub directory not existing for first model download

### DIFF
--- a/scripts/check_sizes_of_models.py
+++ b/scripts/check_sizes_of_models.py
@@ -6,6 +6,8 @@ import os
 
 def get_dir_size(path):
     total = 0
+    if not os.path.exists(path):
+        return total
     with os.scandir(path) as it:
         for entry in it:
             if entry.is_file():

--- a/transformerlab/shared/download_huggingface_model.py
+++ b/transformerlab/shared/download_huggingface_model.py
@@ -100,6 +100,8 @@ def launch_snapshot_with_cancel(repo_id, allow_patterns):
 
 def get_dir_size(path):
     total = 0
+    if not os.path.exists(path):
+        return total
     with os.scandir(path) as it:
         for entry in it:
             # Skip symlinks to avoid double counting


### PR DESCRIPTION
Fixes transformerlab/transformerlab-app#504

Fixes error printed because hub directory within cache doesn't exist when the first size check happens