### PR TITLE
Fix tag used to get docker image in dockerfile

### DIFF
--- a/docker/cpu/docker-compose.yml.tpl
+++ b/docker/cpu/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 services:
   transformerlab-api:
-    image: transformerlab/api:${VERSION}
+    image: transformerlab/api:v${VERSION}
     container_name: transformerlab-api
     ports:
       - "8338:8338"

--- a/docker/gpu/nvidia/docker-compose.yml.tpl
+++ b/docker/gpu/nvidia/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 services:
   transformerlab-api:
-    image: transformerlab/api:${VERSION}-cuda
+    image: transformerlab/api:v${VERSION}-cuda
     container_name: transformerlab-api
     ports:
       - "8338:8338"


### PR DESCRIPTION
I'm not sure why but our docker image is now tagged with a v before the version so our dockerfile doesn't work anymore!