### PR TITLE
Fix Cuda docker and make it so that we only release one dockerfile from common

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
           VERSION="${VERSION#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION=${VERSION}"
-      - name: Build CPU image
-        run: docker build -f docker/cpu/Dockerfile.cpu -t transformerlab/api:${VERSION} .
+      - name: Build image
+        run: docker build -f docker/common/Dockerfile -t transformerlab/api:${VERSION} .
 
-      - name: Build GPU image
-        run: docker build -f docker/gpu/nvidia/Dockerfile.cuda -t transformerlab/api:${VERSION}-cuda .
+      # - name: Build GPU image
+      #   run: docker build -f docker/gpu/nvidia/Dockerfile.cuda -t transformerlab/api:${VERSION}-cuda .
 
-      - name: Push CPU image
+      - name: Push image
         run: docker push transformerlab/api:${VERSION}
 
-      - name: Push GPU image
-        run: docker push transformerlab/api:${VERSION}-cuda
+      # - name: Push GPU image
+      #   run: docker push transformerlab/api:${VERSION}-cuda

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
+
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Set noninteractive mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal dependencies required for the install script
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3.11 \
+    python3-pip \
+    python-is-python3
+
+# Download and run the install.sh script from GitHub.
+RUN curl -fsSL https://raw.githubusercontent.com/transformerlab/transformerlab-api/refs/heads/main/install.sh | bash -s download_transformer_lab install_conda create_conda_environment
+
+EXPOSE 8338
+
+VOLUME ["/root/.transformerlab/"]
+
+WORKDIR /root/.transformerlab/src/
+
+RUN chmod +x ./run.sh
+
+# The entrypoint is set to run the Transformer Lab launcher script.
+ENTRYPOINT ["/bin/bash", "-c", "/root/.transformerlab/src/install.sh install_dependencies && exec /root/.transformerlab/src/run.sh"]

--- a/docker/gpu/nvidia/Dockerfile.cuda
+++ b/docker/gpu/nvidia/Dockerfile.cuda
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     python-is-python3
 
 # Download and run the install.sh script from GitHub.
-RUN curl -fsSL https://raw.githubusercontent.com/transformerlab/transformerlab-api/refs/heads/main/install.sh | bash
+RUN curl -fsSL https://raw.githubusercontent.com/transformerlab/transformerlab-api/refs/heads/main/install.sh | bash -s download_transformer_lab install_conda create_conda_environment
 
 EXPOSE 8338
 
@@ -25,4 +25,4 @@ WORKDIR /root/.transformerlab/src/
 RUN chmod +x ./run.sh
 
 # The entrypoint is set to run the Transformer Lab launcher script.
-ENTRYPOINT ["/root/.transformerlab/src/run.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/root/.transformerlab/src/install.sh install_dependencies && exec /root/.transformerlab/src/run.sh"]


### PR DESCRIPTION
The install dependencies part is moved to when we actually run the container so we don't need to actually have separate docker containers now