### PR TITLE
Add https flag

### DIFF
--- a/api.py
+++ b/api.py
@@ -31,6 +31,7 @@ from fastchat.protocol.openai_api_protocol import (
 )
 
 import transformerlab.db as db
+from transformerlab.shared.ssl_utils import ensure_persistent_self_signed_cert
 from transformerlab.routers import (
     data,
     model,
@@ -434,7 +435,9 @@ def parse_args():
     parser.add_argument("--allowed-origins", type=json.loads, default=["*"], help="allowed origins")
     parser.add_argument("--allowed-methods", type=json.loads, default=["*"], help="allowed methods")
     parser.add_argument("--allowed-headers", type=json.loads, default=["*"], help="allowed headers")
-    parser.add_argument("auto_reinstall_plugins", type=bool, default=False, help="auto reinstall plugins")
+    parser.add_argument("--auto_reinstall_plugins", type=bool, default=False, help="auto reinstall plugins")
+    parser.add_argument("--https", action="store_true", help="Serve the API over HTTPS with a self-signed cert.")
+
 
     return parser.parse_args()
 
@@ -462,7 +465,12 @@ def run():
         allow_headers=args.allowed_headers,
     )
 
-    uvicorn.run("api:app", host=args.host, port=args.port, log_level="warning")
+    if args.https:
+        cert_path, key_path = ensure_persistent_self_signed_cert()
+        uvicorn.run("api:app", host=args.host, port=args.port,
+            log_level="warning", ssl_certfile=cert_path, ssl_keyfile=key_path)
+    else:
+        uvicorn.run("api:app", host=args.host, port=args.port, log_level="warning")
 
 
 if __name__ == "__main__":

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,7 @@ TLABHOST="0.0.0.0"
 PORT="8338"
 
 RELOAD=false
+HTTPS=false
 
 # echo "Your shell is $SHELL"
 # echo "Conda's binary is at ${CONDA_BIN}"
@@ -31,11 +32,12 @@ else
     echo "✅ Conda is installed."
 fi
 
-while getopts crp:h: flag
+while getopts crsp:h: flag
 do
     case "${flag}" in
         c) CUSTOM_ENV=true;;
         r) RELOAD=true;;
+        s) HTTPS=true;;
         p) PORT=${OPTARG};;
         h) TLABHOST=${OPTARG};;
     esac
@@ -82,7 +84,15 @@ fi
 echo "▶️ Starting the API server:"
 if [ "$RELOAD" = true ]; then
     echo "🔁 Reload the server on file changes"
-    uv run -v uvicorn api:app --reload --port ${PORT} --host ${TLABHOST}
+    if [ "$HTTPS" = true ]; then
+        uv run -v python api.py --https --reload --port ${PORT} --host ${TLABHOST}
+    else
+        uv run -v python api.py --reload --port ${PORT} --host ${TLABHOST}
+    fi
 else
-    uv run -v uvicorn api:app --port ${PORT} --host ${TLABHOST} --no-access-log
+    if [ "$HTTPS" = true ]; then
+        uv run -v python api.py --https --port ${PORT} --host ${TLABHOST}
+    else
+        uv run -v python api.py --port ${PORT} --host ${TLABHOST}
+    fi
 fi

--- a/test/shared/test_ssl.py
+++ b/test/shared/test_ssl.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture()
+def ssl_utils(monkeypatch, tmp_path):
+    import transformerlab.shared.ssl_utils as _ssl_utils
+    monkeypatch.setattr(_ssl_utils, "CERT_DIR", tmp_path / "certs", raising=False)
+    monkeypatch.setattr(
+        _ssl_utils,
+        "CERT_PATH",
+        tmp_path / "certs" / "server-cert.pem",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        _ssl_utils,
+        "KEY_PATH",
+        tmp_path / "certs" / "server-key.pem",
+        raising=False,
+    )
+    importlib.reload(_ssl_utils)
+    return _ssl_utils
+
+
+def test_cert_files_are_created_and_reused(ssl_utils):
+    cert_path, key_path = ssl_utils.ensure_persistent_self_signed_cert()
+    assert Path(cert_path).exists()
+    assert Path(key_path).exists()
+    first_mtime = Path(cert_path).stat().st_mtime
+    cert_path2, key_path2 = ssl_utils.ensure_persistent_self_signed_cert()
+    assert cert_path2 == cert_path
+    assert key_path2 == key_path
+    assert Path(cert_path).stat().st_mtime == first_mtime
+
+
+def test_certificate_subject_cn_is_expected(ssl_utils):
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    cert_path, _ = ssl_utils.ensure_persistent_self_signed_cert()
+    cert = x509.load_pem_x509_certificate(Path(cert_path).read_bytes())
+    cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    assert cn == "TransformerLab-Selfhost"
+
+
+def test_private_key_matches_cert(ssl_utils):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography import x509
+    cert_path, key_path = ssl_utils.ensure_persistent_self_signed_cert()
+    cert = x509.load_pem_x509_certificate(Path(cert_path).read_bytes())
+    key = serialization.load_pem_private_key(Path(key_path).read_bytes(), password=None)
+    assert key.key_size == 2048
+    assert cert.public_key().public_numbers() == key.public_key().public_numbers()
+
+
+def test_certificate_sans(ssl_utils):
+    from cryptography import x509
+    cert_path, _ = ssl_utils.ensure_persistent_self_signed_cert()
+    cert = x509.load_pem_x509_certificate(Path(cert_path).read_bytes())
+    sans = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    dns_names = set(sans.get_values_for_type(x509.DNSName))
+    ip_addrs  = {str(ip) for ip in sans.get_values_for_type(x509.IPAddress)}
+    assert dns_names == {"localhost"}
+    assert ip_addrs  == {"127.0.0.1", "::1"}
+
+
+def test_lock_guards_concurrent_writes(ssl_utils, tmp_path):
+    from multiprocessing import Process, Queue
+    def worker(q):
+        q.put(ssl_utils.ensure_persistent_self_signed_cert())
+    q = Queue()
+    procs = [Process(target=worker, args=(q,)) for _ in range(4)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+    results = [q.get() for _ in procs]
+    assert len({r[0] for r in results}) == 1
+    assert len({r[1] for r in results}) == 1

--- a/transformerlab/shared/dirs.py
+++ b/transformerlab/shared/dirs.py
@@ -2,10 +2,8 @@
 
 import os
 from pathlib import Path
-import transformerlab.db as db
 
 from werkzeug.utils import secure_filename
-
 
 """
 TFL_HOME_DIR is the directory that is the parent of the src and workspace directories.
@@ -95,6 +93,7 @@ def experiment_dir_by_name(experiment_name: str) -> str:
 
 
 async def experiment_dir_by_id(experiment_id: str) -> str:
+    from transformerlab import db
     if experiment_id is not None and experiment_id != "undefined":
         experiment = await db.experiment_get(experiment_id)
     else:

--- a/transformerlab/shared/ssl_utils.py
+++ b/transformerlab/shared/ssl_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import datetime as _dt
+import ipaddress as _ip
+from pathlib import Path
+from typing import Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from filelock import FileLock
+
+from transformerlab.shared.dirs import WORKSPACE_DIR
+
+__all__ = [
+    "CERT_DIR",
+    "CERT_PATH",
+    "KEY_PATH",
+    "ensure_persistent_self_signed_cert",
+]
+
+CERT_DIR: Path = Path(WORKSPACE_DIR) / "certs"
+CERT_PATH: Path = CERT_DIR / "server-cert.pem"
+KEY_PATH: Path = CERT_DIR / "server-key.pem"
+
+
+def ensure_persistent_self_signed_cert() -> Tuple[str, str]:
+    lock = CERT_DIR / ".cert.lock"
+    with FileLock(str(lock)):
+        if CERT_PATH.exists() and KEY_PATH.exists():
+            return str(CERT_PATH), str(KEY_PATH)
+        CERT_DIR.mkdir(parents=True, exist_ok=True)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, u"TransformerLab-Selfhost")
+        ])
+        cert_builder = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(_dt.datetime.utcnow() - _dt.timedelta(days=1))
+            .not_valid_after(_dt.datetime.utcnow() + _dt.timedelta(days=3650))
+            .add_extension(
+                x509.SubjectAlternativeName(
+                    [
+                        x509.DNSName(u"localhost"),
+                        x509.IPAddress(_ip.IPv4Address("127.0.0.1")),
+                        x509.IPAddress(_ip.IPv6Address("::1")),
+                    ]
+                ),
+                critical=False,
+            )
+        )
+        cert = cert_builder.sign(key, hashes.SHA256())
+        CERT_PATH.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+        KEY_PATH.write_bytes(
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        )
+        return str(CERT_PATH), str(KEY_PATH)


### PR DESCRIPTION
This PR:

- Adds support for an `--https` flag to serve the API over HTTPS using a self-signed certificate.

- Implements logic in `ssl_utils.py` to generate and persist a self-signed cert and key under the workspace directory.

- Updates run.sh to support a `-s` flag for enabling HTTPS from the CLI. Handles both normal and reload modes accordingly.

- Adds tests for certificate generation, reuse, content (subject, SANs), and concurrency safety.

- Moves an import in `dirs.py` to avoid circular import problems.

This is one of multiple changes aimed at making the server safe to expose directly to the internet. Some cloud providers don't support VPNs or make them hard to set up. So this will make it much easier to use Transformer Lab on multiple cloud providers.