### PR TITLE
Add Docker for AMD GPUs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
           VERSION="${VERSION#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION=${VERSION}"
-      - name: Build image
+      - name: Build General image
         run: docker build -f docker/common/Dockerfile -t transformerlab/api:${VERSION} .
 
-      # - name: Build GPU image
-      #   run: docker build -f docker/gpu/nvidia/Dockerfile.cuda -t transformerlab/api:${VERSION}-cuda .
+      - name: Build ROCm image
+        run: docker build -f docker/gpu/amd/Dockerfile -t transformerlab/api:${VERSION}-rocm docker/gpu/amd
 
       - name: Push image
         run: docker push transformerlab/api:${VERSION}
 
-      # - name: Push GPU image
-      #   run: docker push transformerlab/api:${VERSION}-cuda
+      - name: Push ROCm image
+        run: docker push transformerlab/api:${VERSION}-rocm

--- a/docker/gpu/amd/Dockerfile
+++ b/docker/gpu/amd/Dockerfile
@@ -1,0 +1,37 @@
+FROM rocm/dev-ubuntu-22.04:6.4.1
+
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Set noninteractive mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal dependencies required for the install script
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3.11 \
+    python3-pip \
+    python-is-python3
+
+# Set ROCm environment variables
+ENV ROCM_PATH=/opt/rocm
+ENV PATH=${ROCM_PATH}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${ROCM_PATH}/lib
+
+# Download and run the install.sh script from GitHub.
+RUN curl -fsSL https://raw.githubusercontent.com/transformerlab/transformerlab-api/refs/heads/main/install.sh | bash -s download_transformer_lab install_conda create_conda_environment
+
+EXPOSE 8338
+
+VOLUME ["/root/.transformerlab/"]
+
+WORKDIR /root/.transformerlab/src/
+
+RUN chmod +x ./run.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# # The entrypoint is set to run the Transformer Lab launcher script.
+# ENTRYPOINT ["/bin/bash", "-c", "/root/.transformerlab/src/install.sh install_dependencies && exec /root/.transformerlab/src/run.sh"]

--- a/docker/gpu/amd/README.md
+++ b/docker/gpu/amd/README.md
@@ -1,0 +1,95 @@
+# Transformer Lab AMD GPU Docker Setup
+
+This Docker setup provides a self-contained, ROCm-compatible development environment for TransformerLab on AMD GPUs.
+
+---
+
+## 🧱 Build the Docker Image
+
+From this directory (`transformerlab-api/docker/gpu/amd`), run:
+
+```bash
+docker build -t transformerlab-amd .
+```
+
+---
+
+## ▶️ Run the Container
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --ipc=host \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  -v ~/.transformerlab:/root/.transformerlab \
+  -p 8338:8338 \
+  transformerlab-amd
+```
+
+> ⚠️ You must have AMD ROCm drivers installed on your host system.
+
+---
+
+## 🧪 Development Workflow
+
+Once inside the container:
+
+### Run the app manually:
+
+```bash
+/root/.transformerlab/src/run.sh
+```
+
+### Run tests:
+
+```bash
+cd /root/.transformerlab/src
+pytest
+```
+
+### Source code location:
+
+```bash
+/root/.transformerlab/src
+```
+
+You can edit files directly inside the container, or bind-mount your local source if needed.
+
+---
+
+## 🛠 Useful Debug Tips
+
+### Inspect the image:
+
+```bash
+docker run --rm -it --entrypoint /bin/bash transformerlab-amd
+```
+
+### Check if scripts exist:
+
+```bash
+ls /root/.transformerlab/src
+```
+
+### Check GPU access:
+
+```bash
+rocminfo
+```
+
+---
+
+## 📁 Directory Overview
+
+```text
+transformerlab-api/
+└── docker/
+    └── gpu/
+        └── amd/
+            ├── Dockerfile
+            ├── entrypoint.sh
+            └── README.md  ← you are here
+```

--- a/docker/gpu/amd/entrypoint.sh
+++ b/docker/gpu/amd/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+/root/.transformerlab/src/install.sh install_dependencies
+exec /root/.transformerlab/src/run.sh


### PR DESCRIPTION
- We do not have a ROCM image for transformerlab-api
- This is the Dockerfile anyone can use to create the ROCM docker image for transformer lab
- The `entrypoint.sh` file was added because doing a direct execution with bash -c for entrypoint kept throwing errors even if the file system existed correctly
- Modified Github action to also release a `version-rocm` tagged image for rocm specifically