### PR TITLE
Show Error When Chat Column Is Not in Valid Message Format

### DIFF
--- a/transformerlab/routers/data.py
+++ b/transformerlab/routers/data.py
@@ -336,10 +336,20 @@ async def dataset_preview_with_chat_template(
         for key in result["columns"].keys():
             row[key] = serialize_row(result["columns"][key][i])
         
-        row["__formatted__"] = tokenizer.apply_chat_template(
-                row[chat_column],
-                tokenize=False,
-            )
+        try:
+            row["__formatted__"] = tokenizer.apply_chat_template(
+                    row[chat_column],
+                    tokenize=False,
+                )
+        except Exception:
+            return {
+            "status": "error",
+            "message": (
+                f"Chat template could not be applied.\nThe selected column '{chat_column}' "
+                "must contain a list of dictionaries with 'role' and 'content' keys. \n"
+                f"Example: [{{'role': 'user', 'content': 'Hi'}}]."
+            ),
+        }
         rows.append(row)
 
     return {


### PR DESCRIPTION
Fixes: #689
https://github.com/transformerlab/transformerlab-app/issues/689

Fixed an issue where selecting a non-message-format column for the chat template preview would render nothing. Now, if the column isn't a list of { role, content } messages, the backend returns an error, and the frontend displays a clear warning instead of a blank preview.