### PR TITLE
Add an endpoint to fetch checkpoints from a job

### DIFF
--- a/transformerlab/plugins/mlx_lora_trainer/index.json
+++ b/transformerlab/plugins/mlx_lora_trainer/index.json
@@ -4,7 +4,7 @@
   "description": "MLX Machine learning research on your laptop or in a data center - by Apple",
   "plugin-format": "python",
   "type": "trainer",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "model_architectures": [
     "MLX",
     "CohereForCausalLM",

--- a/transformerlab/plugins/mlx_lora_trainer/index.json
+++ b/transformerlab/plugins/mlx_lora_trainer/index.json
@@ -4,7 +4,7 @@
   "description": "MLX Machine learning research on your laptop or in a data center - by Apple",
   "plugin-format": "python",
   "type": "trainer",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "model_architectures": [
     "MLX",
     "CohereForCausalLM",
@@ -25,7 +25,7 @@
     "SmolLM3ForCausalLM"
   ],
   "supported_hardware_architectures": ["mlx"],
-  "supports": ["sweeps", "chat_template_formatting"],
+  "supports": ["sweeps", "chat_template_formatting", "checkpoints"],
   "files": ["main.py", "setup.sh"],
   "setup-script": "setup.sh",
   "parameters": {

--- a/transformerlab/plugins/mlx_lora_trainer/main.py
+++ b/transformerlab/plugins/mlx_lora_trainer/main.py
@@ -35,12 +35,13 @@ def train_mlx_lora():
     datasets = tlab_trainer.load_dataset(["train", "valid"])
     steps_per_report = tlab_trainer.params.get("steps_per_report", "10")
     save_every = tlab_trainer.params.get("save_every", "1000")
+    tlab_trainer.add_job_data("checkpoints", True)  # save_every implies checkpoints
 
     # Check if LoRA parameters are set
     lora_rank = tlab_trainer.params.get("lora_rank", None)
     lora_alpha = tlab_trainer.params.get("lora_alpha", None)
 
-    #Check if template parameters are set
+    # Check if template parameters are set
     chat_template = tlab_trainer.params.get("formatting_chat_template", None)
     chat_column = tlab_trainer.params.get("chatml_formatted_column", "messages")
     formatting_template = tlab_trainer.params.get("formatting_template", None)
@@ -58,9 +59,6 @@ def train_mlx_lora():
             steps_per_epoch = 1  # Handle case where batch size > dataset size
         total_steps = steps_per_epoch * int(num_train_epochs)
         iters = str(total_steps)
-        steps_per_eval = str(total_steps // int(num_train_epochs))
-        steps_per_report = str(total_steps // int(num_train_epochs))
-        save_every = str(total_steps // int(num_train_epochs))
         print(f"Using epoch-based training: {num_train_epochs} epochs")
         print(f"Training dataset size: {num_examples} examples")
         print(f"Steps per epoch: {steps_per_epoch}")
@@ -93,14 +91,14 @@ def train_mlx_lora():
     data_directory = f"{WORKSPACE_DIR}/plugins/mlx_lora_trainer/data"
     if not os.path.exists(data_directory):
         os.makedirs(data_directory)
-    
+
     prepare_dataset_files(
         data_directory=data_directory,
         datasets=datasets,
         formatting_template=formatting_template,
         chat_template=chat_template,
         model_name=tlab_trainer.params.model_name,
-        chat_column=chat_column
+        chat_column=chat_column,
     )
 
     # Set output directory for the adaptor

--- a/transformerlab/routers/jobs.py
+++ b/transformerlab/routers/jobs.py
@@ -504,7 +504,7 @@ async def get_eval_image(job_id: str, filename: str):
 
 @router.get("/{job_id}/checkpoints")
 async def get_checkpoints(job_id: str):
-    if job_id is None or job_id == "" or job_id == -1:
+    if job_id is None or job_id == "" or job_id == "-1":
         return {"checkpoints": []}
 
     """Get list of checkpoints for a job"""

--- a/transformerlab/routers/jobs.py
+++ b/transformerlab/routers/jobs.py
@@ -109,6 +109,8 @@ async def get_training_job(job_id: str):
 async def get_training_job_output(job_id: str, sweeps: bool = False):
     # First get the template Id from this job:
     job = await db_jobs.job_get(job_id)
+    if job is None:
+        return {"checkpoints": []}
     job_data = job["job_data"]
 
     if not isinstance(job_data, dict):


### PR DESCRIPTION
We add a new endpoint that fetches checkpoints from a job. It is hardcoded to assume default paths that map to how MLX LoRA works (with checkpoints being stored alongside the adaptor).