### PR TITLE
Upgrade transformers and add fastchat support for gpt-oss

### DIFF
--- a/requirements-no-gpu-uv.txt
+++ b/requirements-no-gpu-uv.txt
@@ -571,7 +571,7 @@ tqdm==4.66.5
     #   peft
     #   sentence-transformers
     #   transformers
-transformerlab-inference==0.2.42
+transformerlab-inference==0.2.43
     # via -r requirements.in
 transformers==4.55.0
     # via

--- a/requirements-no-gpu-uv.txt
+++ b/requirements-no-gpu-uv.txt
@@ -633,5 +633,5 @@ yarl==1.18.3
     # via aiohttp
 youtube-transcript-api==1.0.3
     # via markitdown
-zipp==3.21.0
+zipp==3.19.2
     # via importlib-metadata

--- a/requirements-no-gpu-uv.txt
+++ b/requirements-no-gpu-uv.txt
@@ -158,7 +158,9 @@ h11==0.14.0
     #   httpcore
     #   uvicorn
 hf-xet==1.1.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   huggingface-hub
 httpcore==1.0.7
     # via httpx
 httpx==0.28.1
@@ -190,7 +192,7 @@ idna==3.4
     #   yarl
 imageio==2.37.0
     # via scikit-image
-importlib-metadata==8.7.0
+importlib-metadata==7.1.0
     # via
     #   controlnet-aux
     #   diffusers

--- a/requirements-no-gpu-uv.txt
+++ b/requirements-no-gpu-uv.txt
@@ -167,7 +167,7 @@ httpx==0.28.1
     #   transformerlab-inference
 httpx-sse==0.4.0
     # via mcp
-huggingface-hub==0.30.2
+huggingface-hub==0.34.3
     # via
     #   accelerate
     #   controlnet-aux
@@ -571,7 +571,7 @@ tqdm==4.66.5
     #   transformers
 transformerlab-inference==0.2.42
     # via -r requirements.in
-transformers==4.53.2
+transformers==4.55.0
     # via
     #   -r requirements.in
     #   peft

--- a/requirements-rocm-uv.txt
+++ b/requirements-rocm-uv.txt
@@ -574,7 +574,7 @@ tqdm==4.66.5
     #   peft
     #   sentence-transformers
     #   transformers
-transformerlab-inference==0.2.42
+transformerlab-inference==0.2.43
     # via -r requirements-rocm.in
 transformers==4.55.0
     # via

--- a/requirements-rocm-uv.txt
+++ b/requirements-rocm-uv.txt
@@ -167,7 +167,7 @@ httpx==0.28.1
     #   transformerlab-inference
 httpx-sse==0.4.0
     # via mcp
-huggingface-hub==0.30.2
+huggingface-hub==0.34.3
     # via
     #   accelerate
     #   controlnet-aux
@@ -574,7 +574,7 @@ tqdm==4.66.5
     #   transformers
 transformerlab-inference==0.2.42
     # via -r requirements-rocm.in
-transformers==4.53.2
+transformers==4.55.0
     # via
     #   -r requirements-rocm.in
     #   peft

--- a/requirements-rocm-uv.txt
+++ b/requirements-rocm-uv.txt
@@ -158,7 +158,9 @@ h11==0.16.0
     #   httpcore
     #   uvicorn
 hf-xet==1.1.4
-    # via -r requirements-rocm.in
+    # via
+    #   -r requirements-rocm.in
+    #   huggingface-hub
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
@@ -190,7 +192,7 @@ idna==3.4
     #   yarl
 imageio==2.37.0
     # via scikit-image
-importlib-metadata==8.7.0
+importlib-metadata==7.1.0
     # via
     #   controlnet-aux
     #   diffusers

--- a/requirements-rocm-uv.txt
+++ b/requirements-rocm-uv.txt
@@ -642,5 +642,5 @@ yarl==1.20.0
     # via aiohttp
 youtube-transcript-api==1.0.3
     # via markitdown
-zipp==3.22.0
+zipp==3.19.2
     # via importlib-metadata

--- a/requirements-rocm.in
+++ b/requirements-rocm.in
@@ -19,7 +19,7 @@ tiktoken
 torch==2.7.0
 torchaudio==2.7.0
 torchvision==0.22.0
-transformers==4.53.2
+transformers==4.55.0
 peft
 watchfiles
 wandb==0.19.10

--- a/requirements-rocm.in
+++ b/requirements-rocm.in
@@ -31,7 +31,7 @@ markitdown[all]
 hf_xet
 macmon-python
 mcp[cli]
-transformerlab-inference==0.2.42
+transformerlab-inference==0.2.43
 diffusers==0.33.1
 pyrsmi
 controlnet_aux==0.0.10

--- a/requirements-uv.txt
+++ b/requirements-uv.txt
@@ -158,7 +158,9 @@ h11==0.14.0
     #   httpcore
     #   uvicorn
 hf-xet==1.1.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   huggingface-hub
 httpcore==1.0.7
     # via httpx
 httpx==0.28.1
@@ -167,7 +169,7 @@ httpx==0.28.1
     #   transformerlab-inference
 httpx-sse==0.4.0
     # via mcp
-huggingface-hub==0.30.2
+huggingface-hub==0.34.3
     # via
     #   accelerate
     #   controlnet-aux
@@ -609,7 +611,7 @@ tqdm==4.66.5
     #   transformers
 transformerlab-inference==0.2.42
     # via -r requirements.in
-transformers==4.53.2
+transformers==4.55.0
     # via
     #   -r requirements.in
     #   peft

--- a/requirements-uv.txt
+++ b/requirements-uv.txt
@@ -673,5 +673,5 @@ yarl==1.18.3
     # via aiohttp
 youtube-transcript-api==1.0.3
     # via markitdown
-zipp==3.21.0
+zipp==3.19.2
     # via importlib-metadata

--- a/requirements-uv.txt
+++ b/requirements-uv.txt
@@ -609,7 +609,7 @@ tqdm==4.66.5
     #   peft
     #   sentence-transformers
     #   transformers
-transformerlab-inference==0.2.42
+transformerlab-inference==0.2.43
     # via -r requirements.in
 transformers==4.55.0
     # via

--- a/requirements-uv.txt
+++ b/requirements-uv.txt
@@ -192,7 +192,7 @@ idna==3.4
     #   yarl
 imageio==2.37.0
     # via scikit-image
-importlib-metadata==8.7.0
+importlib-metadata==7.1.0
     # via
     #   controlnet-aux
     #   diffusers

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ tiktoken
 torch==2.7.0
 torchaudio==2.7.0
 torchvision==0.22.0
-transformers==4.53.2
+transformers==4.55.0
 peft
 watchfiles
 wandb==0.19.10

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ sentence-transformers
 markitdown[all]
 hf_xet
 macmon-python
-transformerlab-inference==0.2.42
+transformerlab-inference==0.2.43
 diffusers==0.33.1
 nvidia-ml-py
 mcp[cli]

--- a/transformerlab/plugins/fastchat_server/index.json
+++ b/transformerlab/plugins/fastchat_server/index.json
@@ -4,7 +4,7 @@
   "description": "Fastchat loads models for inference using Huggingface Transformers for generation.",
   "plugin-format": "python",
   "type": "loader",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "supports": [
     "chat",
     "completion",
@@ -41,7 +41,8 @@
     "Qwen3MoeForCausalLM",
     "Ernie4_5_MoeForCausalLM",
     "Ernie4_5_ForCausalLM",
-    "SmolLM3ForCausalLM"
+    "SmolLM3ForCausalLM",
+    "GptOssForCausalLM"
   ],
   "supported_hardware_architectures": ["cpu", "cuda", "mlx", "amd"],
   "files": ["main.py", "setup.sh"],

--- a/transformerlab/plugins/fastchat_server/setup.sh
+++ b/transformerlab/plugins/fastchat_server/setup.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # Everything should be installed by default
-uv pip install "transformerlab-inference>=0.2.39"
+if command -v nvidia-smi &> /dev/null; then
+    echo "GPU Compute Capability: $(nvidia-smi --query-gpu=compute_cap --format=csv,noheader,nounits)"
+    
+    # Check if all GPUs have compute capability > 9.0
+    min_compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader,nounits | sort -n | head -1)
+    if (( $(echo "$min_compute_cap > 9.0" | bc -l) )); then
+        echo "All GPUs have compute capability > 9.0"
+        uv pip install torch==2.8.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
+        uv pip install git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels
+        uv pip install "triton==3.4.0"
+        uv pip install -r "kernels>=0.9.0" "peft>=0.17.0" "trl>=0.21.0" "trackio" "transformers>=4.55.0"
+    fi
+fi
 
 if ! command -v rocminfo &> /dev/null; then
     uv pip install bitsandbytes

--- a/transformerlab/plugins/fastchat_server/setup.sh
+++ b/transformerlab/plugins/fastchat_server/setup.sh
@@ -11,7 +11,7 @@ if command -v nvidia-smi &> /dev/null; then
         uv pip install torch==2.8.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
         uv pip install git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels
         uv pip install "triton==3.4.0"
-        uv pip install -r "kernels>=0.9.0" "peft>=0.17.0" "trl>=0.21.0" "trackio" "transformers>=4.55.0"
+        uv pip install "kernels>=0.9.0" "peft>=0.17.0" "trl>=0.21.0" "trackio" "transformers>=4.55.0"
     fi
 fi
 

--- a/transformerlab/plugins/fastchat_server/setup.sh
+++ b/transformerlab/plugins/fastchat_server/setup.sh
@@ -5,7 +5,8 @@ if command -v nvidia-smi &> /dev/null; then
     
     # Check if all GPUs have compute capability > 9.0
     min_compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader,nounits | sort -n | head -1)
-    if (( $(echo "$min_compute_cap > 9.0" | bc -l) )); then
+    # Use awk to compare floating point numbers
+    if awk "BEGIN {exit !($min_compute_cap > 9.0)}"; then
         echo "All GPUs have compute capability > 9.0"
         uv pip install torch==2.8.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
         uv pip install git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels


### PR DESCRIPTION
- This PR upgrades transformers to v4.55.0
- We also add a bunch of setup code in fastchat server which installs torch v2.8 and a custom triton kernel following the instructions in [here](https://github.com/huggingface/gpt-oss-recipes).

- Depends on transformerlab/transformerlab-inference#18
- Once the tlab inference PR is approved, we need to do a release there and then upgrade the tlab inference versions here before merging