### PR TITLE
Don't set worker process if model doesn't start

### DIFF
--- a/api.py
+++ b/api.py
@@ -270,8 +270,6 @@ async def server_worker_start(
     experiment_id: int = None,
     inference_params: str = "",
 ):
-    global worker_process
-
     # the first priority for inference params should be the inference params passed in, then the inference parameters in the experiment
     # first we check to see if any inference params were passed in
     if inference_params != "":
@@ -342,13 +340,13 @@ async def server_worker_start(
     with open(dirs.GLOBAL_LOG_PATH, "a") as global_log:
         global_log.write(f"🏃 Loading Inference Server for {model_name} with {inference_params}\n")
 
-    worker_process = await shared.async_run_python_daemon_and_update_status(
+    process = await shared.async_run_python_daemon_and_update_status(
         python_script=params,
         job_id=job_id,
         begin_string="Application startup complete.",
         set_process_id_function=set_worker_process_id,
     )
-    exitcode = worker_process.returncode
+    exitcode = process.returncode
     if exitcode == 99:
         with open(dirs.GLOBAL_LOG_PATH, "a") as global_log:
             global_log.write(


### PR DESCRIPTION
Changed the returned process to a local variable. For starters, it is redundant because we pass a function that updates worker_process. But also it was setting worker_process on failure which, when combined with another bug we recently fixed, was causing all sorts of hard to debug errors.