### PR TITLE
Fix/worker health race condition

### DIFF
--- a/transformerlab/fastchat_openai_api.py
+++ b/transformerlab/fastchat_openai_api.py
@@ -93,6 +93,7 @@ class ChatCompletionRequest(BaseModel):
 class AudioRequest(BaseModel):
     experiment_id: int
     model: str
+    adaptor: Optional[str] = ""
     text: str
     file_prefix: str
     sample_rate: int

--- a/transformerlab/fastchat_openai_api.py
+++ b/transformerlab/fastchat_openai_api.py
@@ -466,6 +466,7 @@ async def show_available_models():
     controller_address = app_settings.controller_address
     async with httpx.AsyncClient() as client:
         await client.post(controller_address + "/refresh_all_workers")
+        await asyncio.sleep(0.5)  # Allow time for workers to re-register after refresh
         ret = await client.post(controller_address + "/list_models")
     models = ret.json()["models"]
     models.sort()

--- a/transformerlab/fastchat_openai_api.py
+++ b/transformerlab/fastchat_openai_api.py
@@ -479,12 +479,13 @@ async def show_available_models():
                 break
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
-        models.sort()
-        # TODO: return real model permission details
-        model_cards = []
-        for m in models:
-            model_cards.append(ModelCard(id=m, root=m, permission=[ModelPermission()]))
-        return ModelList(data=model_cards)
+    
+    models.sort()
+    # TODO: return real model permission details
+    model_cards = []
+    for m in models:
+        model_cards.append(ModelCard(id=m, root=m, permission=[ModelPermission()]))
+    return ModelList(data=model_cards)
 
 @router.post("/v1/audio/speech", tags=["audio"])
 async def create_audio_tts(request: AudioRequest):


### PR DESCRIPTION
solves #743

https://github.com/transformerlab/transformerlab-app/issues/743

These changes address a race condition between the `/refresh_all_workers` and `/list_models` endpoints. Previously, after triggering a refresh of all workers, the code would immediately request the list of available models. However, there was no guarantee that all workers had finished re-registering, which could result in /list_models returning an empty or incomplete list.

To solve this, we now poll /list_models after calling /refresh_all_workers, waiting until a non-empty model list is returned or a timeout is reached. This ensures that the API only returns the list of models after the refresh operation is complete