### PR TITLE
Fix plugin lookup, refactor library enumeration, and update pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,10 @@ testpaths =
 markers =
     live_server: mark test as requiring a live server
 addopts = -m "not live_server"
+# Ignore temporary plugin/venv directories so third-party package tests are not collected
+norecursedirs = 
+    test/tmp 
+    */venv/* 
+    */site-packages/*
 # to run the live_server tests explicitly, use:
 # pytest -m live_server

--- a/transformerlab/db/db.py
+++ b/transformerlab/db/db.py
@@ -631,12 +631,14 @@ async def get_plugin(slug: str):
 
 async def save_plugin(name: str, type: str):
     async with async_session() as session:
-        plugin = await session.get(Plugin, name)
-        if plugin:
-            plugin.type = type
-        else:
+        # Plugin primary key is integer id, so we must query by unique name
+        result = await session.execute(select(Plugin).where(Plugin.name == name))
+        plugin = result.scalar_one_or_none()
+        if plugin is None:
             plugin = Plugin(name=name, type=type)
             session.add(plugin)
+        else:
+            plugin.type = type
         await session.commit()
     return
 


### PR DESCRIPTION
### Summary

This PR introduces a bug fix for plugin database lookups, a performance and reliability refactor for Python package enumeration, and an enhancement to the pytest configuration.

---

### Changes

* **`pytest.ini`**:
    * Added `norecursedirs` to the `[pytest]` configuration. This prevents the test collector from scanning virtual environments (`*/venv/*`, `*/site-packages/*`) and temporary directories (`test/tmp`), improving performance and preventing the execution of third-party tests.

* **`transformerlab/db/db.py`**:
    * **BUG FIX**: The `save_plugin` function was modified to query for plugins using `select(Plugin).where(Plugin.name == name)` instead of `session.get(Plugin, name)`.
    * **Reason**: The previous implementation incorrectly assumed the `name` field was the primary key. This change corrects the lookup logic to query against the unique `name` column, resolving an issue where existing plugins could not be found and updated.

* **`transformerlab/routers/serverinfo.py`**:
    * **REFACTOR**: The `get_python_library_versions` endpoint was updated to use `importlib.metadata` to enumerate installed packages.
    * **Reason**: This removes the need for a `subprocess` call to `pip`, which improves endpoint performance and security. The previous `pip` method is retained as a fallback for increased resilience.
