### PR TITLE
Fix workflow test fail

### DIFF
--- a/test/api/conftest.py
+++ b/test/api/conftest.py
@@ -8,7 +8,7 @@ os.makedirs("test/tmp/workspace", exist_ok=True)
 os.environ["TFL_HOME_DIR"] = "test/tmp/"
 os.environ["TFL_WORKSPACE_DIR"] = "test/tmp/workspace"
 
-from api import app
+from api import app  # noqa: E402
 
 
 @pytest.fixture(scope="session")

--- a/test/api/test_documents.py
+++ b/test/api/test_documents.py
@@ -9,8 +9,8 @@ os.makedirs("./test/tmp/workspace", exist_ok=True)
 os.environ["TFL_HOME_DIR"] = "./test/tmp/"
 os.environ["TFL_WORKSPACE_DIR"] = "./test/tmp/workspace"
 
-from transformerlab.routers.experiment.documents import document_download_zip
-from fastapi import HTTPException
+from transformerlab.routers.experiment.documents import document_download_zip  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
 
 
 async def test_download_zip_missing_url():

--- a/test/db/test_db.py
+++ b/test/db/test_db.py
@@ -9,7 +9,7 @@ os.environ["TFL_HOME_DIR"] = "./test/tmp/"
 os.environ["TFL_WORKSPACE_DIR"] = "./test/tmp/workspace"
 
 
-from transformerlab.db.db import (
+from transformerlab.db.db import (  # noqa: E402
     delete_plugin,
     experiment_get_by_name,
     get_plugins_of_type,
@@ -47,20 +47,20 @@ from transformerlab.db.db import (
     export_job_create,
 )
 
-from transformerlab.db.sync import (
+from transformerlab.db.sync import (  # noqa: E402
     job_create_sync,
     job_update_status_sync,  # used in dedicated sync tests
     job_update_sync,  # used in dedicated sync tests
     job_mark_as_complete_if_running,  # used in dedicated sync tests
 )
-from transformerlab.services.job_service import (
+from transformerlab.services.job_service import (  # noqa: E402
     job_update_status as service_job_update_status,
     job_update_status_sync as service_job_update_status_sync,
     job_update_sync as service_job_update_sync,
     job_mark_as_complete_if_running as service_job_mark_as_complete_if_running,
 )
 
-from transformerlab.db.datasets import (
+from transformerlab.db.datasets import (  # noqa: E402
     create_huggingface_dataset,
     get_dataset,
     get_datasets,
@@ -69,7 +69,7 @@ from transformerlab.db.datasets import (
     get_generated_datasets,
 )
 
-from transformerlab.db.workflows import (
+from transformerlab.db.workflows import (  # noqa: E402
     workflow_count_queued,
     workflow_count_running,
     workflow_create,
@@ -89,7 +89,7 @@ from transformerlab.db.workflows import (
     workflows_get_by_id,
 )
 
-from transformerlab.db.jobs import (
+from transformerlab.db.jobs import (  # noqa: E402
     job_create,
     job_get,
     job_update_status,  # used in unit tests validating DB-layer behavior
@@ -104,12 +104,11 @@ from transformerlab.db.jobs import (
     job_update,
 )
 
+from transformerlab.db.session import job_cancel_in_progress_jobs  # noqa: E402
+import transformerlab.db.session as db  # noqa: E402
 
-from transformerlab.db.session import job_cancel_in_progress_jobs
-import transformerlab.db.session as db
 
-
-import pytest
+import pytest  # noqa: E402
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The problem was that in the tests, both the home and workspace directories were set to the same place. Because of that, the old database path and the new one ended up being identical. So when the migration code tried to copy the database, it was actually copying it onto itself