### PR TITLE
added /model/logout_from_huggingface API for clearing the hftoken

### DIFF
--- a/transformerlab/routers/model.py
+++ b/transformerlab/routers/model.py
@@ -324,7 +324,31 @@ async def login_to_huggingface():
     except Exception:
         return {"message": "Login failed"}
 
+@router.get(path="/model/logout_from_huggingface")
+async def logout_from_huggingface():
 
+
+   # Logout from Hugging Face using the huggingface_hub logout function.
+
+
+   from huggingface_hub import logout
+   import os
+  
+   try:
+       logout()
+       print("Successfully logged out from Hugging Face")
+      
+       # Also clear the token file manually as a backup
+       # The token is stored at ~/.huggingface/token according to the comment
+       token_file = os.path.expanduser("~/.huggingface/token")
+       if os.path.exists(token_file):
+           os.remove(token_file)
+      
+       return {"message": "OK"}
+      
+   except Exception as e:
+       return {"message": f"Logout failed"}
+       
 @router.get(path="/model/login_to_wandb")
 async def login_to_wandb():
     # TODO: Move all of these logins and their tests to another router outside 'model' to maintain clarity


### PR DESCRIPTION
To address issue #703 on the frontend app (Add option to update Hugging Face credentials in the UI), the backend should remove the cached Hugging Face token. This requires logging out from Hugging Face before setting the new token.